### PR TITLE
[Feat/#46] 취득 예정/완료 button 구현

### DIFF
--- a/app/src/main/java/org/sopt/certi/presentation/type/AcquireButtonType.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/type/AcquireButtonType.kt
@@ -1,0 +1,29 @@
+package org.sopt.certi.presentation.type
+
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.Color
+import org.sopt.certi.R
+import org.sopt.certi.ui.theme.defaultCertiColors
+
+enum class AcquireButtonType(
+    @StringRes val buttonText: Int,
+    val buttonTextColor: Color,
+    val backgroundColor: Color,
+    val pressedBackgroundColor: Color,
+    val borderAvailable: Boolean
+) {
+    FINISH(
+        buttonText = R.string.cert_detail_acquired_button_text,
+        buttonTextColor = defaultCertiColors.white,
+        backgroundColor = defaultCertiColors.purpleBlue,
+        pressedBackgroundColor = defaultCertiColors.mainBlue,
+        borderAvailable = false
+    ),
+    EXPECTED(
+        buttonText = R.string.cert_detail_acquire_expected_button_text,
+        buttonTextColor = defaultCertiColors.purpleBlue,
+        backgroundColor = defaultCertiColors.blueWhite,
+        pressedBackgroundColor = defaultCertiColors.lightBlue,
+        borderAvailable = true
+    )
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
@@ -1,0 +1,106 @@
+package org.sopt.certi.presentation.ui.certrecommend.component.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.certi.R
+import org.sopt.certi.core.util.pressedClickable
+import org.sopt.certi.ui.theme.CertiTheme
+import org.sopt.certi.ui.theme.White
+
+@Composable
+fun AcquiredButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .background(
+                color = if(isPressed) CertiTheme.colors.mainBlue else CertiTheme.colors.purpleBlue,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .clip(RoundedCornerShape(12.dp))
+            .pressedClickable(
+                changePressed = {
+                    isPressed = it
+                },
+                onClick = {
+                    onClick.invoke()
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.cert_detail_acquired_button_text),
+            style = CertiTheme.typography.body.semibold_16,
+            color = CertiTheme.colors.white,
+            modifier = Modifier.padding(vertical = 13.dp)
+        )
+    }
+}
+
+@Composable
+fun AcquiredExpectedButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isPressed by remember { mutableStateOf(false) }
+
+    Box(
+        modifier = modifier
+            .background(
+                color = if(isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.blueWhite,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .clip(RoundedCornerShape(12.dp))
+            .border(width = 1.dp, color = if(isPressed) CertiTheme.colors.skyBlue else CertiTheme.colors.lightBlue, shape = RoundedCornerShape(12.dp))
+            .pressedClickable(
+                changePressed = {
+                    isPressed = it
+                },
+                onClick = {
+                    onClick.invoke()
+                }
+            ),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = stringResource(R.string.cert_detail_acquire_expected_button_text),
+            style = CertiTheme.typography.body.semibold_16,
+            color = CertiTheme.colors.purpleBlue,
+            modifier = Modifier.padding(vertical = 13.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+fun AcquireButtonPreview() {
+    Column(
+        modifier = Modifier.background(color = White),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        AcquiredButton(onClick = {}, modifier = Modifier.fillMaxWidth())
+        AcquiredExpectedButton(onClick = {}, modifier = Modifier.fillMaxWidth())
+    }
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -29,14 +28,14 @@ import org.sopt.certi.ui.theme.White
 @Composable
 fun AcquiredButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     var isPressed by remember { mutableStateOf(false) }
 
     Box(
         modifier = modifier
             .background(
-                color = if(isPressed) CertiTheme.colors.mainBlue else CertiTheme.colors.purpleBlue,
+                color = if (isPressed) CertiTheme.colors.mainBlue else CertiTheme.colors.purpleBlue,
                 shape = RoundedCornerShape(12.dp)
             )
             .clip(RoundedCornerShape(12.dp))
@@ -62,18 +61,18 @@ fun AcquiredButton(
 @Composable
 fun AcquiredExpectedButton(
     onClick: () -> Unit,
-    modifier: Modifier = Modifier,
+    modifier: Modifier = Modifier
 ) {
     var isPressed by remember { mutableStateOf(false) }
 
     Box(
         modifier = modifier
             .background(
-                color = if(isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.blueWhite,
+                color = if (isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.blueWhite,
                 shape = RoundedCornerShape(12.dp)
             )
             .clip(RoundedCornerShape(12.dp))
-            .border(width = 1.dp, color = if(isPressed) CertiTheme.colors.skyBlue else CertiTheme.colors.lightBlue, shape = RoundedCornerShape(12.dp))
+            .border(width = 1.dp, color = if (isPressed) CertiTheme.colors.skyBlue else CertiTheme.colors.lightBlue, shape = RoundedCornerShape(12.dp))
             .pressedClickable(
                 changePressed = {
                     isPressed = it

--- a/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
@@ -39,14 +39,11 @@ fun AcquiredButton(
                 shape = RoundedCornerShape(12.dp)
             )
             .clip(RoundedCornerShape(12.dp))
-            .pressedClickable(
-                changePressed = {
-                    isPressed = it
-                },
-                onClick = {
+            .pressedClickable(changePressed = {
+                isPressed = it
+            }, onClick = {
                     onClick.invoke()
-                }
-            ),
+                }),
         contentAlignment = Alignment.Center
     ) {
         Text(
@@ -72,15 +69,16 @@ fun AcquiredExpectedButton(
                 shape = RoundedCornerShape(12.dp)
             )
             .clip(RoundedCornerShape(12.dp))
-            .border(width = 1.dp, color = if (isPressed) CertiTheme.colors.skyBlue else CertiTheme.colors.lightBlue, shape = RoundedCornerShape(12.dp))
-            .pressedClickable(
-                changePressed = {
-                    isPressed = it
-                },
-                onClick = {
+            .border(
+                width = 1.dp,
+                color = if (isPressed) CertiTheme.colors.skyBlue else CertiTheme.colors.lightBlue,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .pressedClickable(changePressed = {
+                isPressed = it
+            }, onClick = {
                     onClick.invoke()
-                }
-            ),
+                }),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/button/CertDetailButton.kt
@@ -20,13 +20,14 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import org.sopt.certi.R
 import org.sopt.certi.core.util.pressedClickable
+import org.sopt.certi.presentation.type.AcquireButtonType
 import org.sopt.certi.ui.theme.CertiTheme
 import org.sopt.certi.ui.theme.White
 
 @Composable
-fun AcquiredButton(
+fun AcquireButton(
+    acquireButtonType: AcquireButtonType,
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -35,57 +36,28 @@ fun AcquiredButton(
     Box(
         modifier = modifier
             .background(
-                color = if (isPressed) CertiTheme.colors.mainBlue else CertiTheme.colors.purpleBlue,
-                shape = RoundedCornerShape(12.dp)
-            )
-            .clip(RoundedCornerShape(12.dp))
-            .pressedClickable(changePressed = {
-                isPressed = it
-            }, onClick = {
-                    onClick.invoke()
-                }),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(
-            text = stringResource(R.string.cert_detail_acquired_button_text),
-            style = CertiTheme.typography.body.semibold_16,
-            color = CertiTheme.colors.white,
-            modifier = Modifier.padding(vertical = 13.dp)
-        )
-    }
-}
-
-@Composable
-fun AcquiredExpectedButton(
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    var isPressed by remember { mutableStateOf(false) }
-
-    Box(
-        modifier = modifier
-            .background(
-                color = if (isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.blueWhite,
+                color = if (isPressed) acquireButtonType.pressedBackgroundColor else acquireButtonType.backgroundColor,
                 shape = RoundedCornerShape(12.dp)
             )
             .clip(RoundedCornerShape(12.dp))
             .border(
-                width = 1.dp,
+                width = if (acquireButtonType.borderAvailable) 1.dp else 0.dp,
                 color = if (isPressed) CertiTheme.colors.skyBlue else CertiTheme.colors.lightBlue,
                 shape = RoundedCornerShape(12.dp)
             )
-            .pressedClickable(changePressed = {
-                isPressed = it
-            }, onClick = {
-                    onClick.invoke()
-                }),
+            .pressedClickable(
+                changePressed = {
+                    isPressed = it
+                },
+                onClick = onClick
+            ),
         contentAlignment = Alignment.Center
     ) {
         Text(
-            text = stringResource(R.string.cert_detail_acquire_expected_button_text),
+            text = stringResource(acquireButtonType.buttonText),
             style = CertiTheme.typography.body.semibold_16,
-            color = CertiTheme.colors.purpleBlue,
-            modifier = Modifier.padding(vertical = 13.dp)
+            color = acquireButtonType.buttonTextColor,
+            modifier = Modifier.padding(vertical = 14.dp)
         )
     }
 }
@@ -97,7 +69,7 @@ fun AcquireButtonPreview() {
         modifier = Modifier.background(color = White),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
-        AcquiredButton(onClick = {}, modifier = Modifier.fillMaxWidth())
-        AcquiredExpectedButton(onClick = {}, modifier = Modifier.fillMaxWidth())
+        AcquireButton(acquireButtonType = AcquireButtonType.FINISH, onClick = {}, modifier = Modifier.fillMaxWidth())
+        AcquireButton(acquireButtonType = AcquireButtonType.EXPECTED, onClick = {}, modifier = Modifier.fillMaxWidth())
     }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/chip/ReselectInterestedChip.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/certrecommend/component/chip/ReselectInterestedChip.kt
@@ -1,4 +1,4 @@
-package org.sopt.certi.core.component.chip
+package org.sopt.certi.presentation.ui.certrecommend.component.chip
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,9 @@
 
     <!-- Resume ResumeListItem -->
     <string name="resumelistitem_period">%s ~ %s</string>
+    
+    <!-- CertDetailScreen -->
+    <string name="cert_detail_acquired_button_text">취득 완료</string>
+    <string name="cert_detail_acquire_expected_button_text">취득 예정</string>
+
 </resources>


### PR DESCRIPTION
## Related issue 🛠
- closed #46 

## Work Description ✏️
- 자격증 정보화면의 취득 예정/완료 버튼 구현

## Screenshot 📸
<img width="401" alt="스크린샷 2025-07-08 오후 9 34 37" src="https://github.com/user-attachments/assets/f0d40019-26bf-42f5-b5b4-58ab9f6d46d6" />

## To Reviewers 📢
