### PR TITLE
[Feat/#98] 취득예정 자격증 편집 뷰 구현

### DIFF
--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
@@ -124,7 +124,7 @@ fun HomeRoute(
         favoriteCertificationList = favoriteCertificationList,
         isFavorite = isFavorite,
         onFavoriteClicked = { isFavorite = !isFavorite },
-        onClick = { },
+        onDetailClick = { },
         navigateToCertRecommend = { },
         navigateToPreCerti = navigateToPreCerti,
         modifier = Modifier.padding(padding)
@@ -139,7 +139,7 @@ fun HomeScreen(
     favoriteCertificationList: List<CertificationData>,
     isFavorite: Boolean = true,
     onFavoriteClicked: () -> Unit,
-    onClick: () -> Unit,
+    onDetailClick: () -> Unit,
     navigateToCertRecommend: () -> Unit,
     navigateToPreCerti: () -> Unit,
     modifier: Modifier = Modifier
@@ -230,7 +230,7 @@ fun HomeScreen(
                         Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
                         PreCertificationListSection(
                             preCertificationList = preCertificationList,
-                            onClick = onClick
+                            onDetailClick = onDetailClick
                         )
                         Spacer(modifier = Modifier.height(screenHeightDp(36.dp)))
                     }
@@ -328,7 +328,7 @@ private fun PreviewHomeScreen() {
             favoriteCertificationList = favoriteCertificationList,
             isFavorite = true,
             onFavoriteClicked = { isFavorite = !isFavorite },
-            onClick = { },
+            onDetailClick = { },
             navigateToCertRecommend = { },
             navigateToPreCerti = { }
         )

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
@@ -126,7 +126,7 @@ fun HomeRoute(
         onFavoriteClicked = { isFavorite = !isFavorite },
         onClick = { },
         navigateToCertRecommend = { },
-        navigateToPreCerti = { },
+        navigateToPreCerti = navigateToPreCerti,
         modifier = Modifier.padding(padding)
     )
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
@@ -124,7 +124,8 @@ fun HomeRoute(
         favoriteCertificationList = favoriteCertificationList,
         isFavorite = isFavorite,
         onFavoriteClicked = { isFavorite = !isFavorite },
-        navigateToCertRecommend = {},
+        onClick = { },
+        navigateToCertRecommend = { },
         navigateToPreCerti = { },
         modifier = Modifier.padding(padding)
     )
@@ -138,6 +139,7 @@ fun HomeScreen(
     favoriteCertificationList: List<CertificationData>,
     isFavorite: Boolean = true,
     onFavoriteClicked: () -> Unit,
+    onClick: () -> Unit,
     navigateToCertRecommend: () -> Unit,
     navigateToPreCerti: () -> Unit,
     modifier: Modifier = Modifier
@@ -226,7 +228,10 @@ fun HomeScreen(
                         )
                     } else {
                         Spacer(modifier = Modifier.height(screenHeightDp(16.dp)))
-                        PreCertificationListSection(preCertificationList = preCertificationList)
+                        PreCertificationListSection(
+                            preCertificationList = preCertificationList,
+                            onClick = onClick
+                        )
                         Spacer(modifier = Modifier.height(screenHeightDp(36.dp)))
                     }
                 }
@@ -323,6 +328,7 @@ private fun PreviewHomeScreen() {
             favoriteCertificationList = favoriteCertificationList,
             isFavorite = true,
             onFavoriteClicked = { isFavorite = !isFavorite },
+            onClick = { },
             navigateToCertRecommend = { },
             navigateToPreCerti = { }
         )

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
@@ -1,0 +1,52 @@
+package org.sopt.certi.presentation.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import org.sopt.certi.core.util.screenHeightDp
+import org.sopt.certi.core.util.screenWidthDp
+import org.sopt.certi.ui.theme.CertiTheme
+import androidx.compose.material3.Text
+
+
+@Composable
+fun PreCertificationEditRoute(
+    padding: PaddingValues,
+    viewModel: HomeViewModel = hiltViewModel()
+) {
+    PreCertificationEditScreen()
+}
+
+@Composable
+fun PreCertificationEditScreen(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .padding(top = screenHeightDp(60.dp), start = screenWidthDp(20.dp))
+    ) {
+        Text(
+            text = "취득 예정 자격증",
+            style = CertiTheme.typography.subtitle.semibold_20,
+            color = CertiTheme.colors.gray600
+        )
+        LazyColumn(
+            modifier = Modifier
+                .padding(),
+            contentPadding = PaddingValues(top = 36.dp),
+            verticalArrangement = Arrangement.spacedBy(36.dp)
+        ) {
+            items()
+
+
+        }
+
+    }
+
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
@@ -73,7 +73,7 @@ fun PreCertificationEditRoute(
 fun PreCertificationEditScreen(
     preCertificationList: List<CertificationData>,
     showDialog: Boolean,
-    onDelete: () -> Unit = {},
+    onDelete: () -> Unit,
     onDialogConfirm: () -> Unit = {},
     onDialogDismiss: () -> Unit = {},
     modifier: Modifier = Modifier
@@ -102,7 +102,7 @@ fun PreCertificationEditScreen(
             items(preCertificationList) { item ->
                 PreCertificationItem(
                     preCertificationData = item,
-                    onDelete = { }
+                    onDelete = onDelete
                 )
             }
         }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -13,6 +14,17 @@ import org.sopt.certi.core.util.screenHeightDp
 import org.sopt.certi.core.util.screenWidthDp
 import org.sopt.certi.ui.theme.CertiTheme
 import androidx.compose.material3.Text
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import org.sopt.certi.R
+import org.sopt.certi.core.component.dialog.CertiDeleteDialog
+import org.sopt.certi.domain.model.CertificationData
+import org.sopt.certi.presentation.ui.home.component.PreCertificationItem
+import org.sopt.certi.ui.theme.CERTITheme
 
 
 @Composable
@@ -20,33 +32,124 @@ fun PreCertificationEditRoute(
     padding: PaddingValues,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    PreCertificationEditScreen()
+    var showDialog by remember { mutableStateOf(false) }
+
+    val preCertificationList = listOf(
+        CertificationData(
+            certificationId = 1,
+            certificationName = "시각디자인산업기사",
+            averagePeriod = "3개월",
+            nearestTestDate = "2025.05.27",
+            agencyName = "한국산업인력공단",
+            iconIndex = 0
+        ),
+        CertificationData(
+            certificationId = 2,
+            certificationName = "시각디자인산업기사",
+            averagePeriod = "3개월",
+            nearestTestDate = "2025.05.27",
+            agencyName = "한국산업인력공단",
+            iconIndex = 1
+        ),
+        CertificationData(
+            certificationId = 3,
+            certificationName = "시각디자인산업기사",
+            averagePeriod = "3개월",
+            nearestTestDate = "2025.05.27",
+            agencyName = "한국산업인력공단",
+            iconIndex = 2
+        )
+    )
+    PreCertificationEditScreen(
+        preCertificationList = preCertificationList,
+        showDialog = showDialog,
+        onDelete = { showDialog = true },
+        onDialogConfirm = { showDialog = false },
+        onDialogDismiss = { showDialog = false },
+        modifier = Modifier.padding(padding)
+    )
 }
 
 @Composable
 fun PreCertificationEditScreen(
+    preCertificationList: List<CertificationData>,
+    showDialog: Boolean,
+    onDelete: () -> Unit = {},
+    onDialogConfirm: () -> Unit = {},
+    onDialogDismiss: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Column(
         modifier = modifier
-            .padding(top = screenHeightDp(60.dp), start = screenWidthDp(20.dp))
+            .padding(top = screenHeightDp(60.dp), start = screenWidthDp(20.dp), end = screenWidthDp(92.dp))
     ) {
+        if (showDialog) {
+            CertiDeleteDialog(
+                onConfirmClick = onDialogConfirm,
+                onDismissClick = onDialogDismiss
+            )
+        }
+
         Text(
-            text = "취득 예정 자격증",
+            text = stringResource(R.string.home_pre_certification_title),
             style = CertiTheme.typography.subtitle.semibold_20,
             color = CertiTheme.colors.gray600
         )
+
         LazyColumn(
-            modifier = Modifier
-                .padding(),
-            contentPadding = PaddingValues(top = 36.dp),
-            verticalArrangement = Arrangement.spacedBy(36.dp)
+            contentPadding = PaddingValues(vertical = screenHeightDp(36.dp)),
+            verticalArrangement = Arrangement.spacedBy(screenHeightDp(36.dp))
         ) {
-            items()
-
-
+            items(preCertificationList) { item ->
+                PreCertificationItem(
+                    preCertificationData = item,
+                    onDelete = { }
+                )
+            }
         }
-
     }
+}
 
+@Preview(showBackground = true)
+@Composable
+fun PreCertificationEditScreenPreview() {
+    var showDialog by remember { mutableStateOf(false) }
+
+    val mockList = listOf(
+        CertificationData(
+            certificationId = 1,
+            certificationName = "시각디자인산업기사",
+            averagePeriod = "3개월",
+            nearestTestDate = "2025.05.27",
+            agencyName = "한국산업인력공단",
+            iconIndex = 0
+        ),
+        CertificationData(
+            certificationId = 2,
+            certificationName = "시각디자인산업기사",
+            averagePeriod = "3개월",
+            nearestTestDate = "2025.05.27",
+            agencyName = "한국산업인력공단",
+            iconIndex = 1
+        ),
+        CertificationData(
+            certificationId = 3,
+            certificationName = "시각디자인산업기사",
+            averagePeriod = "3개월",
+            nearestTestDate = "2025.05.27",
+            agencyName = "한국산업인력공단",
+            iconIndex = 2
+        )
+    )
+
+    CERTITheme {
+        PreCertificationEditScreen(
+            preCertificationList = mockList,
+            showDialog = showDialog,
+            onDelete = { showDialog = true },
+            onDialogConfirm = { showDialog = false },
+            onDialogDismiss = { showDialog = false },
+            modifier = Modifier
+        )
+    }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/PreCertificationEditScreen.kt
@@ -26,7 +26,6 @@ import org.sopt.certi.domain.model.CertificationData
 import org.sopt.certi.presentation.ui.home.component.PreCertificationItem
 import org.sopt.certi.ui.theme.CERTITheme
 
-
 @Composable
 fun PreCertificationEditRoute(
     padding: PaddingValues,
@@ -145,7 +144,7 @@ fun PreCertificationEditScreenPreview() {
     CERTITheme {
         PreCertificationEditScreen(
             preCertificationList = mockList,
-            showDialog = showDialog,
+            showDialog = true,
             onDelete = { showDialog = true },
             onDialogConfirm = { showDialog = false },
             onDialogDismiss = { showDialog = false },

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationEditSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationEditSection.kt
@@ -1,0 +1,4 @@
+package org.sopt.certi.presentation.ui.home.component
+
+class PreCertificationEditSection {
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationEditSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationEditSection.kt
@@ -1,4 +1,0 @@
-package org.sopt.certi.presentation.ui.home.component
-
-class PreCertificationEditSection {
-}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
@@ -153,12 +153,12 @@ fun PreCertificationItem(
         Icon(
             painter = painterResource(id = R.drawable.ic_close_36),
             contentDescription = null,
-            tint = CertiTheme.colors.gray500,
+            tint = CertiTheme.colors.gray300,
             modifier = Modifier
                 .widthForScreenPercentage(36.dp)
                 .heightForScreenPercentage(36.dp)
                 .showIf(onDelete != null)
-                .noRippleClickable { onDelete }
+                .noRippleClickable { onDelete?.invoke() }
         )
     }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
@@ -37,7 +37,7 @@ import org.sopt.certi.presentation.type.CertiEmojiType
 @Composable
 fun PreCertificationListSection(
     preCertificationList: List<CertificationData>,
-    onClick: () -> Unit,
+    onDetailClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyRow(
@@ -48,7 +48,7 @@ fun PreCertificationListSection(
         items(preCertificationList) { item ->
             PreCertificationItem(
                 preCertificationData = item,
-                onClick = onClick
+                onDetailClick = onDetailClick
             )
         }
     }
@@ -57,7 +57,7 @@ fun PreCertificationListSection(
 @Composable
 fun PreCertificationItem(
     preCertificationData: CertificationData,
-    onClick: (() -> Unit)? = null,
+    onDetailClick: (() -> Unit)? = null,
     onDelete: (() -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
@@ -67,7 +67,7 @@ fun PreCertificationItem(
     ) {
         Card(
             modifier = modifier
-                .then(if (onClick != null) Modifier.noRippleClickable { onClick() } else Modifier),
+                .then(if (onDetailClick != null) Modifier.noRippleClickable { onDetailClick() } else Modifier),
             shape = RoundedCornerShape(12.dp),
             colors = CardDefaults.cardColors(
                 containerColor = CertiTheme.colors.white
@@ -158,7 +158,7 @@ fun PreCertificationItem(
                 .widthForScreenPercentage(36.dp)
                 .heightForScreenPercentage(36.dp)
                 .showIf(onDelete != null)
-                .noRippleClickable { onDelete?.invoke() }
+                .noRippleClickable { onDelete }
         )
     }
 }
@@ -176,7 +176,7 @@ private fun PreCertificationItemPreview_click() {
             iconIndex = 0
         ),
         modifier = Modifier.padding(20.dp),
-        onClick = {}
+        onDetailClick = {}
     )
 }
 

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
@@ -48,7 +48,7 @@ fun PreCertificationListSection(
         items(preCertificationList) { item ->
             PreCertificationItem(
                 preCertificationData = item,
-                onClick = { }
+                onClick = onClick
             )
         }
     }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/PreCertificationItem.kt
@@ -37,6 +37,7 @@ import org.sopt.certi.presentation.type.CertiEmojiType
 @Composable
 fun PreCertificationListSection(
     preCertificationList: List<CertificationData>,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyRow(
@@ -46,7 +47,8 @@ fun PreCertificationListSection(
     ) {
         items(preCertificationList) { item ->
             PreCertificationItem(
-                preCertificationData = item
+                preCertificationData = item,
+                onClick = { }
             )
         }
     }
@@ -55,9 +57,9 @@ fun PreCertificationListSection(
 @Composable
 fun PreCertificationItem(
     preCertificationData: CertificationData,
-    modifier: Modifier = Modifier,
     onClick: (() -> Unit)? = null,
-    onDelete: (() -> Unit)? = null
+    onDelete: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/navigation/HomeNavigation.kt
@@ -5,21 +5,34 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import org.sopt.certi.core.navigation.HomeRoute
 import org.sopt.certi.core.navigation.MainTabRoute
 import org.sopt.certi.presentation.ui.home.HomeRoute
+import org.sopt.certi.presentation.ui.home.PreCertificationEditRoute
 
 fun NavController.navigateToHome(navOptions: NavOptions) {
     navigate(MainTabRoute.Home, navOptions)
 }
 
+fun NavController.navigateToPreCerti() {
+    navigate(HomeRoute.CertPlanned)
+}
+
 fun NavGraphBuilder.homeNavGraph(
-    padding: PaddingValues
+    padding: PaddingValues,
+    navController: NavController
 ) {
     composable<MainTabRoute.Home> {
         HomeRoute(
             padding = padding,
             navigateToCertRecommend = { },
-            navigateToPreCerti = { }
+            navigateToPreCerti = { navController.navigateToPreCerti() }
+        )
+    }
+
+    composable<HomeRoute.CertPlanned> {
+        PreCertificationEditRoute(
+            padding = padding
         )
     }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/main/MainNavHost.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/main/MainNavHost.kt
@@ -56,7 +56,8 @@ fun MainNavHost(
             )
 
             homeNavGraph(
-                padding = padding
+                padding = padding,
+                navController = navigator.navController
             )
 
             certListNavGraph(


### PR DESCRIPTION
## Related issue 🛠
- closed #98 

## Work Description ✏️
취득예정 자격증 편집 뷰 구현

## Screenshot 📸
<img width="405" height="694" alt="스크린샷 2025-07-12 오전 1 44 50" src="https://github.com/user-attachments/assets/7017d160-322c-4e1c-90bc-f1fb83356042" />

## To Reviewers 📢
내비까지 구현 완
