### PR TITLE
[Feat/#107] 이력서-자격증 카드 뒤집기 애니메이션 구현

### DIFF
--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
@@ -14,7 +14,7 @@ fun CertificationCardBack() {
         modifier = Modifier
             .fillMaxSize()
             .background(
-                color = CertiTheme.colors.white,
+                color = CertiTheme.colors.white
             )
     ) {
         Text("뒷면")

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
@@ -1,0 +1,22 @@
+package org.sopt.certi.presentation.ui.resume.component.card
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.sopt.certi.ui.theme.CertiTheme
+
+@Composable
+fun CertificationCardBack() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                color = CertiTheme.colors.white,
+            )
+    ) {
+        Text("뒷면")
+    }
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardFront.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardFront.kt
@@ -14,7 +14,7 @@ fun CertificationCardFront() {
         modifier = Modifier
             .fillMaxSize()
             .background(
-                color = CertiTheme.colors.skyBlue,
+                color = CertiTheme.colors.skyBlue
             )
     ) {
         Text("앞면")

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardFront.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardFront.kt
@@ -1,0 +1,22 @@
+package org.sopt.certi.presentation.ui.resume.component.card
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import org.sopt.certi.ui.theme.CertiTheme
+import androidx.compose.material3.Text
+
+@Composable
+fun CertificationCardFront() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                color = CertiTheme.colors.skyBlue,
+            )
+    ) {
+        Text("앞면")
+    }
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.certi.core.util.noRippleClickable
+import org.sopt.certi.core.util.screenHeightDp
+import org.sopt.certi.core.util.screenWidthDp
 
 import org.sopt.certi.ui.theme.CERTITheme
 import org.sopt.certi.ui.theme.CertiTheme
@@ -56,7 +58,7 @@ fun FlipCardOverlay(
         ) {
             Box(
                 modifier = Modifier
-                    .size(width = 250.dp, height = 376.dp)
+                    .size(width = screenWidthDp(250.dp), height = screenHeightDp(376.dp))
                     .graphicsLayer {
                         this.rotationY = rotationY
                         this.cameraDistance = cameraDistance

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
@@ -1,0 +1,96 @@
+package org.sopt.certi.presentation.ui.resume.component.card
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import org.sopt.certi.core.util.noRippleClickable
+
+import org.sopt.certi.ui.theme.CERTITheme
+import org.sopt.certi.ui.theme.CertiTheme
+
+@Composable
+fun FlipCardOverlay(
+    showCard: Boolean,
+    onDismiss: () -> Unit
+) {
+    var isFlipped by remember { mutableStateOf(false) }
+
+    val rotationY by animateFloatAsState(
+        targetValue = if (isFlipped) 180f else 0f,
+        animationSpec = tween(500, easing = FastOutSlowInEasing),
+        label = "rotationY"
+    )
+    val cameraDistance = with(LocalDensity.current) { 12.dp.toPx() }
+
+    if (showCard) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(CertiTheme.colors.black.copy(alpha = 0.4f))
+                .noRippleClickable { onDismiss() }
+        )
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(width = 250.dp, height = 376.dp)
+                    .graphicsLayer {
+                        this.rotationY = rotationY
+                        this.cameraDistance = cameraDistance
+                        if (rotationY > 90f) {
+                            scaleX = -1f
+                        }
+                    }
+                    .clip(RoundedCornerShape(12.dp))
+                    .noRippleClickable { isFlipped = !isFlipped }
+            ) {
+                if (rotationY <= 90f) {
+                    CertificationCardFront()
+                } else {
+                    CertificationCardBack()
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun FlipCardInteractivePreview() {
+    var showCard by remember { mutableStateOf(true) }
+
+    if (showCard) {
+        CERTITheme {
+            FlipCardOverlay(
+                showCard = showCard,
+                onDismiss = { showCard = false }
+            )
+        }
+    }
+}
+
+

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -92,5 +91,3 @@ fun FlipCardInteractivePreview() {
         }
     }
 }
-
-


### PR DESCRIPTION
## Related issue 🛠
- closed #107 

## Work Description ✏️

뒤집기 애니메이션 구현
- 카드 클릭하면 뒤집힘
- 카드 바깥 클릭하면 카드 사라짐

## Screenshot 📸

https://github.com/user-attachments/assets/de781805-0960-4692-8dcf-1d1462b8998c

## To Reviewers 📢
일단 애니메이션만 구현함요