### PR TITLE
[Fix/#163] 이력서 뷰 1차 QA 적용

### DIFF
--- a/app/src/main/java/org/sopt/certi/data/mapper/todomain/acquisition/AcquisitionListResponseMapper.kt
+++ b/app/src/main/java/org/sopt/certi/data/mapper/todomain/acquisition/AcquisitionListResponseMapper.kt
@@ -5,14 +5,13 @@ import org.sopt.certi.data.remote.dto.response.GetAcquisitionListResponseDto
 import org.sopt.certi.domain.model.certification.CertificationData
 
 fun GetAcquisitionListResponseDto.toDomain(): List<CertificationData> {
-    return getAcquisitionResponses.map {
+    return acquisitionListDetailResponses.map {
         CertificationData(
             certificationId = it.acquisitionId,
             index = it.index,
             certificationName = it.name,
             createdAt = it.createdAt.toLocalDateOrMin(),
             cardFrontImageUrl = it.cardFrontImageUrl,
-            cardBackImageUrl = it.cardBackImageUrl,
             tags = it.tags
         )
     }

--- a/app/src/main/java/org/sopt/certi/data/remote/dto/response/GetAcquisitionListResponseDto.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/dto/response/GetAcquisitionListResponseDto.kt
@@ -5,8 +5,8 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class GetAcquisitionListResponseDto(
-    @SerialName("getAcquisitionResponses")
-    val getAcquisitionResponses: List<AcquisitionResponseDto>
+    @SerialName("acquisitionListDetailResponses")
+    val acquisitionListDetailResponses: List<AcquisitionResponseDto>
 )
 
 @Serializable
@@ -21,8 +21,6 @@ data class AcquisitionResponseDto(
     val createdAt: String,
     @SerialName("cardFrontImageUrl")
     val cardFrontImageUrl: String,
-    @SerialName("cardBackImageUrl")
-    val cardBackImageUrl: String,
     @SerialName("tags")
     val tags: List<String>
 )

--- a/app/src/main/java/org/sopt/certi/presentation/type/CertCardColorType.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/type/CertCardColorType.kt
@@ -11,28 +11,28 @@ enum class CertCardColorType(
     val chipTextColor: Color
 ) {
     BLUE(
-        certificationIndex = 0,
+        certificationIndex = 2,
         textColor = defaultCertiColors.white,
         subTextColor = defaultCertiColors.white,
         chipBackgroundColor = defaultCertiColors.lightPurple,
         chipTextColor = defaultCertiColors.mainBlue
     ),
     SKYBLUE(
-        certificationIndex = 1,
+        certificationIndex = 0,
         textColor = defaultCertiColors.gray600,
         subTextColor = defaultCertiColors.mainBlue,
         chipBackgroundColor = defaultCertiColors.lightPurple,
         chipTextColor = defaultCertiColors.mainBlue
     ),
     WHITE(
-        certificationIndex = 2,
+        certificationIndex = 3,
         textColor = defaultCertiColors.gray600,
         subTextColor = defaultCertiColors.mainBlue,
         chipBackgroundColor = defaultCertiColors.skyBlue,
         chipTextColor = defaultCertiColors.purpleWhite
     ),
     YELLOW(
-        certificationIndex = 3,
+        certificationIndex = 1,
         textColor = defaultCertiColors.gray600,
         subTextColor = defaultCertiColors.mainBlue,
         chipBackgroundColor = defaultCertiColors.lightPurple,

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeAddActivitiesScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeAddActivitiesScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -101,7 +102,8 @@ fun ResumeAddActivitiesScreen(
                     value = uiState.organizationValue,
                     onValueChange = onOrganizationValueChange,
                     maxLength = 10,
-                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
+                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp)),
+                    imeAction = ImeAction.Next
                 )
             }
 
@@ -111,7 +113,8 @@ fun ResumeAddActivitiesScreen(
                     value = uiState.activityValue,
                     onValueChange = onActivityValueChange,
                     maxLength = 10,
-                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
+                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp)),
+                    imeAction = ImeAction.Next
                 )
             }
 
@@ -121,7 +124,8 @@ fun ResumeAddActivitiesScreen(
                     value = uiState.descriptionValue,
                     onValueChange = onDescriptionValue,
                     maxLength = 16,
-                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
+                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp)),
+                    imeAction = ImeAction.Done
                 )
             }
         }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeAddActivitiesScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeAddActivitiesScreen.kt
@@ -131,7 +131,7 @@ fun ResumeAddActivitiesScreen(
         }
 
         CertiBasicButton(
-            buttonText = stringResource(R.string.resume_add_button),
+            buttonText = stringResource(R.string.button_add),
             onClick = onAddClick,
             enabled = uiState.addButtonEnabled,
             modifier = Modifier

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
@@ -140,6 +140,7 @@ fun ResumeScreen(
                 ResumeListSection(
                     title = stringResource(R.string.resume_section_experience_title),
                     onClick = navigateToWorkExperience,
+                    emptyText = stringResource(R.string.resume_empty_experience_message),
                     resumeListItems = experienceList
                 )
             }
@@ -156,6 +157,7 @@ fun ResumeScreen(
                 ResumeListSection(
                     title = stringResource(R.string.resume_section_activity_title),
                     onClick = navigateToActivities,
+                    emptyText = stringResource(R.string.resume_empty_activity_message),
                     resumeListItems = activityList
                 )
             }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeViewModel.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeViewModel.kt
@@ -93,7 +93,7 @@ class ResumeViewModel @Inject constructor(
         _acquiredCertificationListLoadState.value = UiState.Loading
         getAcquisitionListUseCase.invoke().fold(
             onSuccess = {
-                val acquiredCertificationList = it.take(3)
+                val acquiredCertificationList = it
                 _acquiredCertificationListLoadState.emit(UiState.Success(acquiredCertificationList))
             },
             onFailure = {

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeAddButton.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeAddButton.kt
@@ -8,6 +8,10 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -18,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
 import org.sopt.certi.R
 import org.sopt.certi.core.util.noRippleClickable
+import org.sopt.certi.core.util.pressedClickable
 import org.sopt.certi.core.util.roundedBackgroundWithBorder
 import org.sopt.certi.core.util.screenHeightDp
 import org.sopt.certi.core.util.screenWidthDp
@@ -29,21 +34,25 @@ fun ResumeAddButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    var isPressed by remember { mutableStateOf(false) }
+
     Row(
         modifier = modifier
+            .pressedClickable(
+                changePressed = { isPressed = it },
+                onClick = onClick
+            )
             .roundedBackgroundWithBorder(
                 cornerRadius = 8.dp,
-                backgroundColor = CertiTheme.colors.purpleWhite
+                backgroundColor =(if (isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.purpleWhite)
             )
-            .padding(vertical = screenHeightDp(12.dp), horizontal = screenWidthDp(20.dp))
-            .noRippleClickable { onClick() },
+            .padding(vertical = screenHeightDp(12.dp), horizontal = screenWidthDp(20.dp)),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_resume_add_24),
             contentDescription = null,
             tint = CertiTheme.colors.mainBlue,
-            modifier = Modifier.size(min(screenHeightDp(24.dp), screenWidthDp(24.dp)))
         )
 
         Spacer(modifier = Modifier.width(screenWidthDp(2.dp)))

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeAddButton.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeAddButton.kt
@@ -3,7 +3,6 @@ package org.sopt.certi.presentation.ui.resume.component
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -19,9 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.min
 import org.sopt.certi.R
-import org.sopt.certi.core.util.noRippleClickable
 import org.sopt.certi.core.util.pressedClickable
 import org.sopt.certi.core.util.roundedBackgroundWithBorder
 import org.sopt.certi.core.util.screenHeightDp
@@ -44,7 +41,7 @@ fun ResumeAddButton(
             )
             .roundedBackgroundWithBorder(
                 cornerRadius = 8.dp,
-                backgroundColor =(if (isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.purpleWhite)
+                backgroundColor = (if (isPressed) CertiTheme.colors.lightBlue else CertiTheme.colors.purpleWhite)
             )
             .padding(vertical = screenHeightDp(12.dp), horizontal = screenWidthDp(20.dp)),
         verticalAlignment = Alignment.CenterVertically
@@ -52,7 +49,7 @@ fun ResumeAddButton(
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_resume_add_24),
             contentDescription = null,
-            tint = CertiTheme.colors.mainBlue,
+            tint = CertiTheme.colors.mainBlue
         )
 
         Spacer(modifier = Modifier.width(screenWidthDp(2.dp)))

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeCertificationSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeCertificationSection.kt
@@ -62,7 +62,7 @@ fun ResumeCertificationSection(
         }
         if (acquiredCertificationList.isEmpty()) {
             CertiEmptySection(
-                text = stringResource(R.string.resume_empty_experience_message)
+                text = stringResource(R.string.resume_empty_certification_message)
             )
         } else {
             ResumeCertificationContent(
@@ -110,6 +110,7 @@ private fun ResumeEmptyCertificationSectionPreview() {
         ResumeListSection(
             title = stringResource(R.string.resume_section_experience_title),
             onClick = { },
+            emptyText = stringResource(R.string.resume_empty_certification_message),
             resumeListItems = listOf()
         )
     }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeCertificationSmallCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeCertificationSmallCard.kt
@@ -12,15 +12,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import org.sopt.certi.R
 import org.sopt.certi.core.component.chip.CertiChipList
-import org.sopt.certi.core.util.heightForScreenPercentage
 import org.sopt.certi.core.util.noRippleClickable
 import org.sopt.certi.core.util.screenHeightDp
 import org.sopt.certi.core.util.screenWidthDp
@@ -47,7 +44,7 @@ fun ResumeCertificationSmallCard(
             contentDescription = null,
             modifier = Modifier
                 .widthForScreenPercentage(200.dp)
-                .aspectRatio(2f/3f),
+                .aspectRatio(2f / 3f),
             contentScale = ContentScale.Crop
         )
 

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeCertificationSmallCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeCertificationSmallCard.kt
@@ -3,6 +3,7 @@ package org.sopt.certi.presentation.ui.resume.component
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -42,13 +43,11 @@ fun ResumeCertificationSmallCard(
             .noRippleClickable { onClick() }
     ) {
         AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(certification.cardFrontImageUrl)
-                .build(),
+            model = certification.cardFrontImageUrl,
             contentDescription = null,
             modifier = Modifier
                 .widthForScreenPercentage(200.dp)
-                .heightForScreenPercentage(300.dp),
+                .aspectRatio(2f/3f),
             contentScale = ContentScale.Crop
         )
 

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDateInputSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDateInputSection.kt
@@ -99,7 +99,7 @@ private fun ResumeDateTextField(
             ),
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Number,
-            imeAction = ImeAction.Done
+            imeAction = ImeAction.Next
         ),
         decorationBox = { innerTextField ->
             Box(

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDateInputSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDateInputSection.kt
@@ -92,7 +92,7 @@ private fun ResumeDateTextField(
         modifier = modifier
             .widthForScreenPercentage(108.dp)
             .roundedBackgroundWithBorder(
-                cornerRadius = 1.dp,
+                cornerRadius = 4.dp,
                 backgroundColor = CertiTheme.colors.white,
                 borderColor = CertiTheme.colors.gray100,
                 borderWidth = 1.dp

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDateInputSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDateInputSection.kt
@@ -90,7 +90,7 @@ private fun ResumeDateTextField(
             color = CertiTheme.colors.gray600
         ),
         modifier = modifier
-            .widthForScreenPercentage(108.dp)
+            .widthForScreenPercentage(120.dp)
             .roundedBackgroundWithBorder(
                 cornerRadius = 4.dp,
                 backgroundColor = CertiTheme.colors.white,

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDescriptionSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDescriptionSection.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -28,7 +29,7 @@ fun ResumeDescriptionSection(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Column(
-            modifier = Modifier.width(screenWidthDp(104.dp))
+            modifier = Modifier.widthIn(max = screenWidthDp(120.dp))
         ) {
             Text(
                 text = stringResource(

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeListSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeListSection.kt
@@ -27,6 +27,7 @@ import org.sopt.certi.ui.theme.CertiTheme
 fun ResumeListSection(
     title: String,
     onClick: () -> Unit,
+    emptyText: String,
     resumeListItems: List<ActivityData>,
     modifier: Modifier = Modifier
 ) {
@@ -54,7 +55,7 @@ fun ResumeListSection(
         }
         if (resumeListItems.isEmpty()) {
             CertiEmptySection(
-                text = stringResource(R.string.resume_empty_experience_message)
+                text = emptyText
             )
         } else {
             ResumeListContent(resumeListItems = resumeListItems)
@@ -69,6 +70,7 @@ private fun ResumeEmptyListSectionPreview() {
         ResumeListSection(
             title = stringResource(R.string.resume_section_experience_title),
             onClick = { },
+            emptyText = stringResource(R.string.resume_empty_experience_message),
             resumeListItems = listOf()
         )
     }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeTextField.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeTextField.kt
@@ -29,6 +29,7 @@ fun ResumeTextField(
     onValueChange: (String) -> Unit,
     maxLength: Int,
     modifier: Modifier = Modifier,
+    imeAction: ImeAction = ImeAction.Done,
     placeholder: String = stringResource(R.string.resume_textfield_placeholder)
 ) {
     BasicTextField(
@@ -41,7 +42,7 @@ fun ResumeTextField(
             color = CertiTheme.colors.gray600
         ),
         keyboardOptions = KeyboardOptions.Default.copy(
-            imeAction = ImeAction.Done
+            imeAction = imeAction
         ),
         singleLine = false,
         decorationBox = { innerTextField ->

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeTextInputSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeTextInputSection.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.sopt.certi.core.util.screenHeightDp
@@ -19,7 +20,8 @@ fun ResumeTextInputSection(
     value: String,
     onValueChange: (String) -> Unit,
     maxLength: Int,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    imeAction: ImeAction = ImeAction.Done
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
@@ -29,7 +31,8 @@ fun ResumeTextInputSection(
         ResumeTextField(
             value = value,
             onValueChange = onValueChange,
-            maxLength = maxLength
+            maxLength = maxLength,
+            imeAction = imeAction
         )
     }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
@@ -47,9 +47,7 @@ fun CertificationCardBack(
             .clip(RoundedCornerShape(12.dp))
     ) {
         AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(certificationData.cardBackImageUrl)
-                .build(),
+            model = certificationData.cardBackImageUrl,
             contentDescription = null,
             contentScale = ContentScale.Crop,
             modifier = Modifier.matchParentSize()

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
@@ -11,7 +11,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -19,13 +21,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
-import coil.request.ImageRequest
 import org.sopt.certi.R
 import org.sopt.certi.core.component.chip.CertiChipList
 import org.sopt.certi.core.util.screenHeightDp
@@ -41,6 +41,8 @@ fun CertificationCardBack(
     nickname: String,
     modifier: Modifier = Modifier
 ) {
+    val scrollState = rememberScrollState()
+
     Box(
         modifier = modifier
             .fillMaxSize()
@@ -55,7 +57,7 @@ fun CertificationCardBack(
 
         Column(
             modifier = Modifier
-                .padding(start = screenWidthDp(24.dp), end = screenWidthDp(24.dp), top = screenHeightDp(36.dp)),
+                .padding(horizontal = screenWidthDp(24.dp), vertical = screenHeightDp(36.dp)),
             verticalArrangement = Arrangement.Center
         ) {
             Text(
@@ -69,19 +71,20 @@ fun CertificationCardBack(
                 categories = certificationData.tags
             )
             Spacer(modifier = Modifier.height(screenHeightDp(36.dp)))
-            Text(
-                text = certificationData.description,
-                style = CertiTheme.typography.caption.regular_12,
-                color = CertiTheme.colors.white
-            )
-        }
 
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = screenWidthDp(24.dp), bottom = screenHeightDp(34.dp)),
-            verticalArrangement = Arrangement.spacedBy(screenHeightDp(4.dp))
-        ) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(scrollState)
+            ) {
+                Text(
+                    text = certificationData.description,
+                    style = CertiTheme.typography.caption.regular_12,
+                    color = CertiTheme.colors.white
+                )
+            }
+            Spacer(modifier = Modifier.height(screenHeightDp(36.dp)))
+
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(screenWidthDp(4.dp))

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/CertificationCardBack.kt
@@ -101,6 +101,7 @@ fun CertificationCardBack(
                     color = CertiTheme.colors.white
                 )
             }
+            Spacer(modifier = Modifier.height(screenHeightDp(4.dp)))
 
             AcquiredDateChip(certificationData = certificationData)
         }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
@@ -22,6 +23,7 @@ import androidx.compose.ui.window.DialogProperties
 import org.sopt.certi.core.util.noRippleClickable
 import org.sopt.certi.core.util.screenHeightDp
 import org.sopt.certi.core.util.screenWidthDp
+import org.sopt.certi.core.util.widthForScreenPercentage
 import org.sopt.certi.domain.model.certification.CertificationData
 import org.sopt.certi.ui.theme.CERTITheme
 import java.time.LocalDate
@@ -51,7 +53,8 @@ fun FlipCardOverlay(
     ) {
         Box(
             modifier = Modifier
-                .size(width = screenWidthDp(250.dp), height = screenHeightDp(376.dp))
+                .widthForScreenPercentage(250.dp)
+                .aspectRatio(2f/3f)
                 .graphicsLayer {
                     this.rotationY = rotationY
                     this.cameraDistance = cameraDistance

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/card/FlipCard.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,8 +20,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import org.sopt.certi.core.util.noRippleClickable
-import org.sopt.certi.core.util.screenHeightDp
-import org.sopt.certi.core.util.screenWidthDp
 import org.sopt.certi.core.util.widthForScreenPercentage
 import org.sopt.certi.domain.model.certification.CertificationData
 import org.sopt.certi.ui.theme.CERTITheme
@@ -54,7 +51,7 @@ fun FlipCardOverlay(
         Box(
             modifier = Modifier
                 .widthForScreenPercentage(250.dp)
-                .aspectRatio(2f/3f)
+                .aspectRatio(2f / 3f)
                 .graphicsLayer {
                     this.rotationY = rotationY
                     this.cameraDistance = cameraDistance

--- a/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/ResumeAddWorkExperienceScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/ResumeAddWorkExperienceScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -96,7 +97,8 @@ fun ResumeAddWorkExperienceScreen(
                     value = uiState.organizationValue,
                     onValueChange = onOrganizationValueChange,
                     maxLength = 10,
-                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
+                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp)),
+                    imeAction = ImeAction.Next
                 )
             }
 
@@ -106,7 +108,8 @@ fun ResumeAddWorkExperienceScreen(
                     value = uiState.roleValue,
                     onValueChange = onRoleValueChange,
                     maxLength = 10,
-                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
+                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp)),
+                    imeAction = ImeAction.Next
                 )
             }
 
@@ -116,7 +119,8 @@ fun ResumeAddWorkExperienceScreen(
                     value = uiState.descriptionValue,
                     onValueChange = onDescriptionValueChange,
                     maxLength = 16,
-                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
+                    modifier = Modifier.padding(bottom = screenHeightDp(36.dp)),
+                    imeAction = ImeAction.Done
                 )
             }
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,8 +101,8 @@
     <string name="resume_work_experience_description">직무 관련 내용</string>
 
     <!-- ResumeActivitiesScreen -->
-    <string name="resume_activities_edit_title">대내외활동 수정</string>
-    <string name="resume_activities_add_title">대내외활동 추가</string>
+    <string name="resume_activities_edit_title">대내외 활동 수정</string>
+    <string name="resume_activities_add_title">대내외 활동 추가</string>
     <string name="resume_activities_period">기간</string>
     <string name="resume_activities_organization">소속</string>
     <string name="resume_activities_activity">활동</string>


### PR DESCRIPTION
## Related issue 🛠
- closed #163 

## Work Description ✏️
- 자격증 카드 비율 맞추기
- 카드 설명 스크롤로 수정
- 자격증 카드 전체 리스트로 수정
- 대내외 활동 empty 뷰 텍스트 수정
- 취득한 자격증 empty 뷰 텍스트 수정
- 대내외 활동 편집 뷰 타이틀 수정
- 추가하기 버튼 pressed 상태 추가
- 텍스트필드 radius 수정
- 자격증 카드 DTO 수정

## Screenshot 📸


## Uncompleted Tasks 😅
- N/A

## To Reviewers 📢
