### PR TITLE
[Feat/IPLC-21] 이력서 파트 api 연결

### DIFF
--- a/app/src/main/java/org/sopt/certi/core/navigation/RouteModel.kt
+++ b/app/src/main/java/org/sopt/certi/core/navigation/RouteModel.kt
@@ -66,6 +66,9 @@ sealed interface ResumeRoute : Route {
     data object AddWorkExperience : ResumeRoute
 
     @Serializable
+    data class EditWorkExperience(val activityId: Long) : ResumeRoute
+
+    @Serializable
     data object Activities : ResumeRoute
 
     @Serializable

--- a/app/src/main/java/org/sopt/certi/core/navigation/RouteModel.kt
+++ b/app/src/main/java/org/sopt/certi/core/navigation/RouteModel.kt
@@ -73,6 +73,9 @@ sealed interface ResumeRoute : Route {
 
     @Serializable
     data object AddActivities : ResumeRoute
+
+    @Serializable
+    data class EditActivities(val activityId: Long) : ResumeRoute
 }
 
 sealed interface CertRecommendRoute : Route {

--- a/app/src/main/java/org/sopt/certi/data/mapper/todomain/user/UserInfoResponseDtoMapper.kt
+++ b/app/src/main/java/org/sopt/certi/data/mapper/todomain/user/UserInfoResponseDtoMapper.kt
@@ -4,7 +4,10 @@ import org.sopt.certi.data.remote.dto.response.UserInfoResponseDto
 import org.sopt.certi.domain.model.user.UserInfoData
 
 fun UserInfoResponseDto.toDomain() = UserInfoData(
+    nickname = nickname,
     name = name,
     university = university,
-    major = major
+    major = major,
+    profileImageUrl = profileImage,
+    birthday = birthDate
 )

--- a/app/src/main/java/org/sopt/certi/data/remote/datasource/ActivityRemoteDataSource.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/datasource/ActivityRemoteDataSource.kt
@@ -14,4 +14,5 @@ interface ActivityRemoteDataSource {
     ): NullableApiResponse<Unit>
     suspend fun getActivityList(): ApiResponse<GetActivityListResponseDto>
     suspend fun deleteActivity(activityId: Long): NullableApiResponse<Unit>
+    suspend fun editActivity(activityId: Long, startAt: String, endAt: String, place: String, name: String, description: String): NullableApiResponse<Unit>
 }

--- a/app/src/main/java/org/sopt/certi/data/remote/datasource/CareerRemoteDataSource.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/datasource/CareerRemoteDataSource.kt
@@ -14,4 +14,5 @@ interface CareerRemoteDataSource {
     ): NullableApiResponse<Unit>
     suspend fun getCareerList(): ApiResponse<GetCareersResponseDto>
     suspend fun deleteCareer(careerId: Long): NullableApiResponse<Unit>
+    suspend fun editCareer(careerId: Long, startAt: String, endAt: String, place: String, name: String, description: String): NullableApiResponse<Unit>
 }

--- a/app/src/main/java/org/sopt/certi/data/remote/datasourceimpl/ActivityRemoteDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/datasourceimpl/ActivityRemoteDataSourceImpl.kt
@@ -19,4 +19,7 @@ class ActivityRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun deleteActivity(activityId: Long): NullableApiResponse<Unit> =
         activityService.deleteActivity(activityId)
+
+    override suspend fun editActivity(activityId: Long, startAt: String, endAt: String, place: String, name: String, description: String): NullableApiResponse<Unit> =
+        activityService.editActivity(activityId, ActivityCareerRequestDto(startAt, endAt, place, name, description))
 }

--- a/app/src/main/java/org/sopt/certi/data/remote/datasourceimpl/ActivityRemoteDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/datasourceimpl/ActivityRemoteDataSourceImpl.kt
@@ -3,7 +3,7 @@ package org.sopt.certi.data.remote.datasourceimpl
 import org.sopt.certi.data.remote.datasource.ActivityRemoteDataSource
 import org.sopt.certi.data.remote.dto.base.ApiResponse
 import org.sopt.certi.data.remote.dto.base.NullableApiResponse
-import org.sopt.certi.data.remote.dto.request.AddActivityCareerRequestDto
+import org.sopt.certi.data.remote.dto.request.ActivityCareerRequestDto
 import org.sopt.certi.data.remote.dto.response.GetActivityListResponseDto
 import org.sopt.certi.data.remote.service.ActivityService
 import javax.inject.Inject
@@ -12,7 +12,7 @@ class ActivityRemoteDataSourceImpl @Inject constructor(
     private val activityService: ActivityService
 ) : ActivityRemoteDataSource {
     override suspend fun addActivity(startAt: String, endAt: String, place: String, name: String, description: String): NullableApiResponse<Unit> =
-        activityService.addActivity(addActivityRequest = AddActivityCareerRequestDto(startAt, endAt, place, name, description))
+        activityService.addActivity(addActivityRequest = ActivityCareerRequestDto(startAt, endAt, place, name, description))
 
     override suspend fun getActivityList(): ApiResponse<GetActivityListResponseDto> =
         activityService.getActivityList()

--- a/app/src/main/java/org/sopt/certi/data/remote/datasourceimpl/CareerRemoteDataSourceImpl.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/datasourceimpl/CareerRemoteDataSourceImpl.kt
@@ -3,7 +3,7 @@ package org.sopt.certi.data.remote.datasourceimpl
 import org.sopt.certi.data.remote.datasource.CareerRemoteDataSource
 import org.sopt.certi.data.remote.dto.base.ApiResponse
 import org.sopt.certi.data.remote.dto.base.NullableApiResponse
-import org.sopt.certi.data.remote.dto.request.AddActivityCareerRequestDto
+import org.sopt.certi.data.remote.dto.request.ActivityCareerRequestDto
 import org.sopt.certi.data.remote.dto.response.GetCareersResponseDto
 import org.sopt.certi.data.remote.service.CareerService
 import javax.inject.Inject
@@ -12,7 +12,9 @@ class CareerRemoteDataSourceImpl @Inject constructor(
     private val careerService: CareerService
 ) : CareerRemoteDataSource {
     override suspend fun addCareer(startAt: String, endAt: String, place: String, name: String, description: String): NullableApiResponse<Unit> =
-        careerService.addCareers(addCareerRequest = AddActivityCareerRequestDto(startAt, endAt, place, name, description))
+        careerService.addCareers(addCareerRequest = ActivityCareerRequestDto(startAt, endAt, place, name, description))
     override suspend fun getCareerList(): ApiResponse<GetCareersResponseDto> = careerService.getCareerList()
     override suspend fun deleteCareer(careerId: Long): NullableApiResponse<Unit> = careerService.deleteCareer(careerId)
+    override suspend fun editCareer(careerId: Long, startAt: String, endAt: String, place: String, name: String, description: String): NullableApiResponse<Unit> =
+        careerService.editCareer(careerId, ActivityCareerRequestDto(startAt, endAt, place, name, description))
 }

--- a/app/src/main/java/org/sopt/certi/data/remote/dto/request/ActivityCareerRequestDto.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/dto/request/ActivityCareerRequestDto.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class AddActivityCareerRequestDto(
+data class ActivityCareerRequestDto(
     @SerialName("startAt")
     val startAt: String,
     @SerialName("endAt")

--- a/app/src/main/java/org/sopt/certi/data/remote/dto/response/UserInfoResponseDto.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/dto/response/UserInfoResponseDto.kt
@@ -6,9 +6,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class UserInfoResponseDto(
     @SerialName("nickname")
+    val nickname: String,
+    @SerialName("name")
     val name: String,
     @SerialName("university")
     val university: String,
     @SerialName("major")
-    val major: String
+    val major: String,
+    @SerialName("profileImage")
+    val profileImage: String?,
+    @SerialName("birthDate")
+    val birthDate: String?
 )

--- a/app/src/main/java/org/sopt/certi/data/remote/service/ActivityService.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/service/ActivityService.kt
@@ -2,7 +2,7 @@ package org.sopt.certi.data.remote.service
 
 import org.sopt.certi.data.remote.dto.base.ApiResponse
 import org.sopt.certi.data.remote.dto.base.NullableApiResponse
-import org.sopt.certi.data.remote.dto.request.AddActivityCareerRequestDto
+import org.sopt.certi.data.remote.dto.request.ActivityCareerRequestDto
 import retrofit2.http.Body
 import retrofit2.http.POST
 import org.sopt.certi.data.remote.dto.response.GetActivityListResponseDto
@@ -13,7 +13,7 @@ import retrofit2.http.Path
 interface ActivityService {
     @POST("/api/v1/activity")
     suspend fun addActivity(
-        @Body addActivityRequest: AddActivityCareerRequestDto
+        @Body addActivityRequest: ActivityCareerRequestDto
     ): NullableApiResponse<Unit>
 
     @GET("/api/v1/activity")

--- a/app/src/main/java/org/sopt/certi/data/remote/service/ActivityService.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/service/ActivityService.kt
@@ -8,6 +8,7 @@ import retrofit2.http.POST
 import org.sopt.certi.data.remote.dto.response.GetActivityListResponseDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface ActivityService {
@@ -22,5 +23,11 @@ interface ActivityService {
     @DELETE("/api/v1/activity/{activity-id}")
     suspend fun deleteActivity(
         @Path("activity-id") activityId: Long
+    ): NullableApiResponse<Unit>
+
+    @PUT("/api/v1/activity/{activity-id}")
+    suspend fun editActivity(
+        @Path("activity-id") activityId: Long,
+        @Body editActivityRequest: ActivityCareerRequestDto
     ): NullableApiResponse<Unit>
 }

--- a/app/src/main/java/org/sopt/certi/data/remote/service/CareerService.kt
+++ b/app/src/main/java/org/sopt/certi/data/remote/service/CareerService.kt
@@ -2,18 +2,19 @@ package org.sopt.certi.data.remote.service
 
 import org.sopt.certi.data.remote.dto.base.ApiResponse
 import org.sopt.certi.data.remote.dto.base.NullableApiResponse
-import org.sopt.certi.data.remote.dto.request.AddActivityCareerRequestDto
+import org.sopt.certi.data.remote.dto.request.ActivityCareerRequestDto
 import retrofit2.http.Body
 import retrofit2.http.POST
 import org.sopt.certi.data.remote.dto.response.GetCareersResponseDto
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface CareerService {
     @POST("/api/v1/careers")
     suspend fun addCareers(
-        @Body addCareerRequest: AddActivityCareerRequestDto
+        @Body addCareerRequest: ActivityCareerRequestDto
     ): NullableApiResponse<Unit>
 
     @GET("/api/v1/careers")
@@ -22,5 +23,11 @@ interface CareerService {
     @DELETE("/api/v1/careers/{career-id}")
     suspend fun deleteCareer(
         @Path("career-id") careerId: Long
+    ): NullableApiResponse<Unit>
+
+    @PUT("/api/v1/careers/{career-id}")
+    suspend fun editCareer(
+        @Path("career-id") careerId: Long,
+        @Body editCareerRequest: ActivityCareerRequestDto
     ): NullableApiResponse<Unit>
 }

--- a/app/src/main/java/org/sopt/certi/data/repositoryimpl/ActivityRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/certi/data/repositoryimpl/ActivityRepositoryImpl.kt
@@ -30,4 +30,10 @@ class ActivityRepositoryImpl @Inject constructor(
             .handleNullableApiResponse()
             .getOrThrow()
     }
+
+    override suspend fun editActivity(activityId: Long, startAt: String, endAt: String, place: String, name: String, description: String): Result<Unit> = safeApiCall {
+        activityRemoteDataSource.editActivity(activityId, startAt, endAt, place, name, description)
+            .handleNullableApiResponse()
+            .getOrThrow()
+    }
 }

--- a/app/src/main/java/org/sopt/certi/data/repositoryimpl/CareerRepositoryImpl.kt
+++ b/app/src/main/java/org/sopt/certi/data/repositoryimpl/CareerRepositoryImpl.kt
@@ -30,4 +30,10 @@ class CareerRepositoryImpl @Inject constructor(
             .handleNullableApiResponse()
             .getOrThrow()
     }
+
+    override suspend fun editCareer(careerId: Long, startAt: String, endAt: String, place: String, name: String, description: String): Result<Unit> = safeApiCall {
+        careerRemoteDataSource.editCareer(careerId, startAt, endAt, place, name, description)
+            .handleNullableApiResponse()
+            .getOrThrow()
+    }
 }

--- a/app/src/main/java/org/sopt/certi/di/UseCaseModule.kt
+++ b/app/src/main/java/org/sopt/certi/di/UseCaseModule.kt
@@ -34,6 +34,7 @@ import org.sopt.certi.domain.usecase.acquisition.DeleteAcquisitionUseCase
 import org.sopt.certi.domain.usecase.acquisition.GetAcquisitionDetailUseCase
 import org.sopt.certi.domain.usecase.activity.DeleteActivityUseCase
 import org.sopt.certi.domain.usecase.career.DeleteCareerUseCase
+import org.sopt.certi.domain.usecase.career.EditCareerUseCase
 import org.sopt.certi.domain.usecase.certification.GetJobCertListUseCase
 import org.sopt.certi.domain.usecase.certification.GetCertInfoUseCase
 import org.sopt.certi.domain.usecase.certification.GetRecommendCertListUseCase
@@ -163,6 +164,12 @@ object UseCaseModule {
     fun provideAddCareerUseCase(
         careerRepository: CareerRepository
     ): AddCareerUseCase = AddCareerUseCase(careerRepository)
+
+    @Provides
+    @Singleton
+    fun provideEditCareerUseCase(
+        careerRepository: CareerRepository
+    ): EditCareerUseCase = EditCareerUseCase(careerRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/org/sopt/certi/di/UseCaseModule.kt
+++ b/app/src/main/java/org/sopt/certi/di/UseCaseModule.kt
@@ -33,6 +33,7 @@ import org.sopt.certi.domain.usecase.acquisition.AcquiredCertUseCase
 import org.sopt.certi.domain.usecase.acquisition.DeleteAcquisitionUseCase
 import org.sopt.certi.domain.usecase.acquisition.GetAcquisitionDetailUseCase
 import org.sopt.certi.domain.usecase.activity.DeleteActivityUseCase
+import org.sopt.certi.domain.usecase.activity.EditActivityUseCase
 import org.sopt.certi.domain.usecase.career.DeleteCareerUseCase
 import org.sopt.certi.domain.usecase.career.EditCareerUseCase
 import org.sopt.certi.domain.usecase.certification.GetJobCertListUseCase
@@ -206,6 +207,12 @@ object UseCaseModule {
     fun provideAddActivityUseCase(
         activityRepository: ActivityRepository
     ): AddActivityUseCase = AddActivityUseCase(activityRepository)
+
+    @Provides
+    @Singleton
+    fun provideEditActivityUseCase(
+        activityRepository: ActivityRepository
+    ): EditActivityUseCase = EditActivityUseCase(activityRepository)
 
     @Provides
     @Singleton

--- a/app/src/main/java/org/sopt/certi/domain/model/user/UserInfoData.kt
+++ b/app/src/main/java/org/sopt/certi/domain/model/user/UserInfoData.kt
@@ -7,6 +7,6 @@ data class UserInfoData(
     val major: String = "",
     val category: List<String> = emptyList<String>(),
     val track: String = "",
-    val birthday: String = "",
+    val birthday: String? = null,
     val profileImageUrl: String? = null
 )

--- a/app/src/main/java/org/sopt/certi/domain/repository/ActivityRepository.kt
+++ b/app/src/main/java/org/sopt/certi/domain/repository/ActivityRepository.kt
@@ -12,4 +12,5 @@ interface ActivityRepository {
     ): Result<Unit>
     suspend fun getActivityList(): Result<List<ActivityData>>
     suspend fun deleteActivity(activityId: Long): Result<Unit>
+    suspend fun editActivity(activityId: Long, startAt: String, endAt: String, place: String, name: String, description: String): Result<Unit>
 }

--- a/app/src/main/java/org/sopt/certi/domain/repository/CareerRepository.kt
+++ b/app/src/main/java/org/sopt/certi/domain/repository/CareerRepository.kt
@@ -12,4 +12,5 @@ interface CareerRepository {
     ): Result<Unit>
     suspend fun getCareerList(): Result<List<ActivityData>>
     suspend fun deleteCareer(careerId: Long): Result<Unit>
+    suspend fun editCareer(careerId: Long, startAt: String, endAt: String, place: String, name: String, description: String): Result<Unit>
 }

--- a/app/src/main/java/org/sopt/certi/domain/usecase/activity/EditActivityUseCase.kt
+++ b/app/src/main/java/org/sopt/certi/domain/usecase/activity/EditActivityUseCase.kt
@@ -1,0 +1,16 @@
+package org.sopt.certi.domain.usecase.activity
+
+import org.sopt.certi.domain.repository.ActivityRepository
+
+class EditActivityUseCase(
+    private val activityRepository: ActivityRepository
+) {
+    suspend operator fun invoke(
+        activityId: Long,
+        startAt: String,
+        endAt: String,
+        place: String,
+        name: String,
+        description: String
+    ): Result<Unit> = activityRepository.editActivity(activityId, startAt, endAt, place, name, description)
+}

--- a/app/src/main/java/org/sopt/certi/domain/usecase/career/EditCareerUseCase.kt
+++ b/app/src/main/java/org/sopt/certi/domain/usecase/career/EditCareerUseCase.kt
@@ -1,0 +1,16 @@
+package org.sopt.certi.domain.usecase.career
+
+import org.sopt.certi.domain.repository.CareerRepository
+
+class EditCareerUseCase(
+    private val careerRepository: CareerRepository
+) {
+    suspend operator fun invoke(
+        careerId: Long,
+        startAt: String,
+        endAt: String,
+        place: String,
+        name: String,
+        description: String
+    ): Result<Unit> = careerRepository.editCareer(careerId, startAt, endAt, place, name, description)
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/EditActivitiesViewModel.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/EditActivitiesViewModel.kt
@@ -1,0 +1,105 @@
+package org.sopt.certi.presentation.ui.activity
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.sopt.certi.domain.usecase.activity.EditActivityUseCase
+import org.sopt.certi.domain.usecase.activity.GetActivityListUseCase
+import org.sopt.certi.presentation.ui.activity.state.AddActivityUiState
+import javax.inject.Inject
+
+@HiltViewModel
+class EditActivitiesViewModel @Inject constructor(
+    private val getActivityListUseCase: GetActivityListUseCase,
+    private val editActivityUseCase: EditActivityUseCase,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val activityId: Long = checkNotNull(savedStateHandle["activityId"])
+
+    private val _startDate = MutableStateFlow("")
+    private val _endDate = MutableStateFlow("")
+    private val _organizationValue = MutableStateFlow("")
+    private val _activityValue = MutableStateFlow("")
+    private val _descriptionValue = MutableStateFlow("")
+
+    private val _editActivitySuccess = MutableStateFlow(false)
+    val editActivitySuccess: StateFlow<Boolean> = _editActivitySuccess
+
+    val addActivityUiState: StateFlow<AddActivityUiState> =
+        combine(
+            _startDate,
+            _endDate,
+            _organizationValue,
+            _activityValue,
+            _descriptionValue
+        ) { startDate, endDate, organization, activity, description ->
+            AddActivityUiState(
+                startDate = startDate,
+                endDate = endDate,
+                organizationValue = organization,
+                activityValue = activity,
+                descriptionValue = description,
+                addButtonEnabled = listOf(startDate, endDate, organization, activity, description).all { it.isNotBlank() }
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = AddActivityUiState("", "", "", "", "", false)
+        )
+
+    init {
+        loadInitial()
+    }
+
+    private fun loadInitial() {
+        viewModelScope.launch {
+            getActivityListUseCase.invoke().fold(
+                onSuccess = { list ->
+                    val item = list.find { it.activityId == activityId }
+                    if (item != null) {
+                        _startDate.value = item.startAt
+                        _endDate.value = item.endAt
+                        _organizationValue.value = item.organization
+                        _activityValue.value = item.role /* 또는 name/activityValue 필드에 맞게 */
+                        _descriptionValue.value = item.description
+                    }
+                },
+                onFailure = { }
+            )
+        }
+    }
+
+    fun onStartDateChanged(value: String) { _startDate.value = value }
+    fun onEndDateChanged(value: String) { _endDate.value = value }
+    fun onOrganizationChanged(value: String) { _organizationValue.value = value }
+    fun onActivityChanged(value: String) { _activityValue.value = value }
+    fun onDescriptionChanged(value: String) { _descriptionValue.value = value }
+
+    fun editActivity() {
+        viewModelScope.launch {
+            editActivityUseCase(
+                activityId = activityId,
+                startAt = _startDate.value,
+                endAt = _endDate.value,
+                place = _organizationValue.value,
+                name = _activityValue.value,
+                description = _descriptionValue.value
+            ).fold(
+                onSuccess = { _editActivitySuccess.value = true },
+                onFailure = { _editActivitySuccess.value = false }
+            )
+        }
+    }
+
+    fun resetEditActivitySuccess() {
+        _editActivitySuccess.value = false
+    }
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeActivitiesScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeActivitiesScreen.kt
@@ -36,6 +36,7 @@ import org.sopt.certi.ui.theme.CertiTheme
 fun ResumeActivitiesRoute(
     padding: PaddingValues,
     onNavigateToAddActivities: () -> Unit,
+    onNavigateToEditActivities: (Long) -> Unit,
     viewModel: ActivityViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.activityUiState.collectAsStateWithLifecycle()
@@ -59,6 +60,7 @@ fun ResumeActivitiesRoute(
             onNavigateToAdd = onNavigateToAddActivities,
             resumeDataList = (uiState.activityListLoadState as UiState.Success).data.toImmutableList(),
             onDeleteClick = { viewModel.onDeleteClick(it) },
+            onItemClick = onNavigateToEditActivities,
             modifier = Modifier.padding(padding)
         )
         is UiState.Empty -> {}
@@ -86,6 +88,7 @@ fun ResumeActivitiesScreen(
     onNavigateToAdd: () -> Unit,
     resumeDataList: ImmutableList<ActivityData>,
     onDeleteClick: (Long) -> Unit,
+    onItemClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -115,7 +118,7 @@ fun ResumeActivitiesScreen(
             ResumeEditListItem(
                 resumeListItem = resumeData,
                 onDeleteClick = onDeleteClick,
-                onClick = {},
+                onClick = onItemClick,
                 modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
             )
         }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeActivitiesScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeActivitiesScreen.kt
@@ -115,6 +115,7 @@ fun ResumeActivitiesScreen(
             ResumeEditListItem(
                 resumeListItem = resumeData,
                 onDeleteClick = onDeleteClick,
+                onClick = {},
                 modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
             )
         }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeAddActivitiesScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/ResumeAddActivitiesScreen.kt
@@ -48,12 +48,44 @@ fun ResumeAddActivitiesRoute(
 
     ResumeAddActivitiesScreen(
         uiState = uiState,
-        onStartDateValueChange = { viewModel.onStartDateChanged(it) },
-        onEndDateValueChange = { viewModel.onEndDateChanged(it) },
-        onOrganizationValueChange = { viewModel.onOrganizationChanged(it) },
-        onActivityValueChange = { viewModel.onActivityChanged(it) },
-        onDescriptionValue = { viewModel.onDescriptionChanged(it) },
-        onAddClick = { viewModel.addActivity() },
+        titleResId = R.string.resume_activities_add_title,
+        buttonTextResId = R.string.button_add,
+        onStartDateValueChange = viewModel::onStartDateChanged,
+        onEndDateValueChange = viewModel::onEndDateChanged,
+        onOrganizationValueChange = viewModel::onOrganizationChanged,
+        onActivityValueChange = viewModel::onActivityChanged,
+        onDescriptionValue = viewModel::onDescriptionChanged,
+        onButtonClick = viewModel::addActivity,
+        modifier = Modifier.padding(padding)
+    )
+}
+
+@Composable
+fun ResumeEditActivitiesRoute(
+    padding: PaddingValues,
+    navigateToResume: () -> Unit,
+    viewModel: EditActivitiesViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.addActivityUiState.collectAsStateWithLifecycle()
+    val editSuccess by viewModel.editActivitySuccess.collectAsStateWithLifecycle()
+
+    LaunchedEffect(editSuccess) {
+        if (editSuccess) {
+            navigateToResume()
+            viewModel.resetEditActivitySuccess()
+        }
+    }
+
+    ResumeAddActivitiesScreen(
+        uiState = uiState,
+        titleResId = R.string.resume_activities_edit_title,
+        buttonTextResId = R.string.button_edit,
+        onStartDateValueChange = viewModel::onStartDateChanged,
+        onEndDateValueChange = viewModel::onEndDateChanged,
+        onOrganizationValueChange = viewModel::onOrganizationChanged,
+        onActivityValueChange = viewModel::onActivityChanged,
+        onDescriptionValue = viewModel::onDescriptionChanged,
+        onButtonClick = viewModel::editActivity,
         modifier = Modifier.padding(padding)
     )
 }
@@ -61,12 +93,14 @@ fun ResumeAddActivitiesRoute(
 @Composable
 fun ResumeAddActivitiesScreen(
     uiState: AddActivityUiState,
+    titleResId: Int,
+    buttonTextResId: Int,
     onStartDateValueChange: (String) -> Unit,
     onEndDateValueChange: (String) -> Unit,
     onOrganizationValueChange: (String) -> Unit,
     onActivityValueChange: (String) -> Unit,
     onDescriptionValue: (String) -> Unit,
-    onAddClick: () -> Unit,
+    onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -80,7 +114,7 @@ fun ResumeAddActivitiesScreen(
         ) {
             item {
                 Text(
-                    text = stringResource(R.string.resume_activities_add_title),
+                    text = stringResource(titleResId),
                     style = CertiTheme.typography.subtitle.semibold_20,
                     color = CertiTheme.colors.gray600,
                     modifier = Modifier.padding(
@@ -136,8 +170,8 @@ fun ResumeAddActivitiesScreen(
         }
 
         CertiBasicButton(
-            buttonText = stringResource(R.string.button_add),
-            onClick = onAddClick,
+            buttonText = stringResource(buttonTextResId),
+            onClick = onButtonClick,
             enabled = uiState.addButtonEnabled,
             modifier = Modifier
                 .fillMaxWidth()
@@ -171,9 +205,9 @@ private fun ResumeAddActivitiesScreen_Preview() {
             onOrganizationValueChange = { uiState = uiState.copy(organizationValue = it) },
             onActivityValueChange = { uiState = uiState.copy(activityValue = it) },
             onDescriptionValue = { uiState = uiState.copy(descriptionValue = it) },
-            onAddClick = {
-                uiState = uiState.copy(addButtonEnabled = !uiState.addButtonEnabled)
-            }
+            onButtonClick = {},
+            titleResId = R.string.resume_activities_add_title,
+            buttonTextResId = R.string.button_add
         )
     }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/activity/navigation/ActivityNavigation.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/activity/navigation/ActivityNavigation.kt
@@ -9,10 +9,15 @@ import org.sopt.certi.core.navigation.MainTabRoute
 import org.sopt.certi.core.navigation.ResumeRoute
 import org.sopt.certi.presentation.ui.activity.ResumeActivitiesRoute
 import org.sopt.certi.presentation.ui.activity.ResumeAddActivitiesRoute
+import org.sopt.certi.presentation.ui.activity.ResumeEditActivitiesRoute
 import org.sopt.certi.presentation.ui.resume.navigation.navigateToResume
 
 fun NavController.navigateToAddActivities() {
     navigate(ResumeRoute.AddActivities)
+}
+
+fun NavController.navigateToEditActivities(activityId: Long) {
+    navigate(ResumeRoute.EditActivities(activityId))
 }
 
 fun NavGraphBuilder.activityNavGraph(
@@ -22,7 +27,8 @@ fun NavGraphBuilder.activityNavGraph(
     composable<ResumeRoute.Activities> {
         ResumeActivitiesRoute(
             padding = padding,
-            onNavigateToAddActivities = navController::navigateToAddActivities
+            onNavigateToAddActivities = navController::navigateToAddActivities,
+            onNavigateToEditActivities = navController::navigateToEditActivities
         )
     }
 
@@ -34,6 +40,17 @@ fun NavGraphBuilder.activityNavGraph(
                     navOptions {
                         popUpTo(MainTabRoute.Resume) { inclusive = true }
                     }
+                )
+            }
+        )
+    }
+
+    composable<ResumeRoute.EditActivities> {
+        ResumeEditActivitiesRoute(
+            padding = padding,
+            navigateToResume = {
+                navController.navigateToResume(
+                    navOptions { popUpTo(MainTabRoute.Resume) { inclusive = true } }
                 )
             }
         )

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeScreen.kt
@@ -306,7 +306,7 @@ fun HomeScreen(
                         horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         Text(
-                            text = stringResource(R.string.home_recommend_title, userInfo.name),
+                            text = stringResource(R.string.home_recommend_title, userInfo.nickname),
                             style = CertiTheme.typography.subtitle.semibold_20,
                             color = CertiTheme.colors.gray600
                         )

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/HomeViewModel.kt
@@ -60,7 +60,7 @@ class HomeViewModel @Inject constructor(
             userInfoUseCase()
                 .onSuccess { result ->
                     _userInfoLoadState.value = UiState.Success(result)
-                    tokenManager.saveNickName(result.name)
+                    tokenManager.saveNickName(result.nickname)
                 }
                 .onFailure {
                     _userInfoLoadState.value = UiState.Failure(it.toString())

--- a/app/src/main/java/org/sopt/certi/presentation/ui/home/component/UserInfoSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/home/component/UserInfoSection.kt
@@ -30,10 +30,10 @@ fun UserInfoSection(
     userInfoData: UserInfoData,
     modifier: Modifier = Modifier
 ) {
-    val displayName = if (userInfoData.name.length >= 4) {
-        userInfoData.name.take(3) + "…"
+    val displayName = if (userInfoData.nickname.length >= 4) {
+        userInfoData.nickname.take(3) + "…"
     } else {
-        userInfoData.name
+        userInfoData.nickname
     }
 
     Column(

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
@@ -116,7 +116,7 @@ fun ResumeScreen(
                     name = userInfo.name,
                     university = userInfo.university,
                     major = userInfo.major,
-                    birthday = userInfo.birthday,
+                    birthday = userInfo.birthday ?: "",
                     modifier = Modifier.padding(top = screenHeightDp(16.dp))
                 )
             }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
@@ -116,7 +116,8 @@ fun ResumeScreen(
                     name = userInfo.name,
                     university = userInfo.university,
                     major = userInfo.major,
-                    birthday = userInfo.birthday ?: "",
+                    birthday = userInfo.birthday ?: stringResource(R.string.resume_certification_birthday_empty),
+                    profileImageUrl = userInfo.profileImageUrl,
                     modifier = Modifier.padding(top = screenHeightDp(16.dp))
                 )
             }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeScreen.kt
@@ -43,6 +43,7 @@ import org.sopt.certi.presentation.ui.resume.sideEffect.ResumeSideEffect
 @Composable
 fun ResumeRoute(
     padding: PaddingValues,
+    navigateToMyPage: () -> Unit,
     navigateToMyCert: () -> Unit,
     navigateToWorkExperience: () -> Unit,
     navigateToActivities: () -> Unit,
@@ -81,6 +82,7 @@ fun ResumeRoute(
             onCertificationClick = { certificationId ->
                 viewModel.onCertificationClick(certificationId)
             },
+            navigateToMyPage = navigateToMyPage,
             navigateToMyCert = navigateToMyCert,
             navigateToWorkExperience = navigateToWorkExperience,
             navigateToActivities = navigateToActivities,
@@ -96,6 +98,7 @@ fun ResumeRoute(
 @Composable
 fun ResumeScreen(
     userInfo: UserInfoData,
+    navigateToMyPage: () -> Unit,
     acquiredCertificationList: ImmutableList<CertificationData>,
     experienceList: ImmutableList<ActivityData>,
     activityList: ImmutableList<ActivityData>,
@@ -118,6 +121,7 @@ fun ResumeScreen(
                     major = userInfo.major,
                     birthday = userInfo.birthday ?: stringResource(R.string.resume_certification_birthday_empty),
                     profileImageUrl = userInfo.profileImageUrl,
+                    navigateToMyPage = navigateToMyPage,
                     modifier = Modifier.padding(top = screenHeightDp(16.dp))
                 )
             }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeViewModel.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/ResumeViewModel.kt
@@ -16,6 +16,7 @@ import org.sopt.certi.core.state.UiState
 import org.sopt.certi.domain.model.ActivityData
 import org.sopt.certi.domain.model.certification.CertificationData
 import org.sopt.certi.domain.model.user.UserInfoData
+import org.sopt.certi.domain.usecase.UserInfoUseCase
 import org.sopt.certi.domain.usecase.acquisition.GetAcquisitionDetailUseCase
 import org.sopt.certi.domain.usecase.acquisition.GetAcquisitionListUseCase
 import org.sopt.certi.domain.usecase.activity.GetActivityListUseCase
@@ -26,6 +27,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class ResumeViewModel @Inject constructor(
+    private val userInfoUseCase: UserInfoUseCase,
     private val getAcquisitionListUseCase: GetAcquisitionListUseCase,
     private val getCareerListUseCase: GetCareerListUseCase,
     private val getActivityListUseCase: GetActivityListUseCase,
@@ -75,18 +77,17 @@ class ResumeViewModel @Inject constructor(
         getActivityList()
     }
 
-    private fun getUserInfo() = viewModelScope.launch {
-        _userInfoLoadState.value = UiState.Loading
-        _userInfoLoadState.emit(
-            UiState.Success(
-                UserInfoData(
-                    name = "김서티",
-                    university = "서티대학교",
-                    major = "시각디자인학과",
-                    birthday = "2001. 03. 26 (만 24세)"
-                )
-            )
-        )
+    private fun getUserInfo() {
+        viewModelScope.launch {
+            _userInfoLoadState.value = UiState.Loading
+            userInfoUseCase()
+                .onSuccess { result ->
+                    _userInfoLoadState.value = UiState.Success(result)
+                }
+                .onFailure {
+                    _userInfoLoadState.value = UiState.Failure(it.toString())
+                }
+        }
     }
 
     private fun getAcquiredCertificationList() = viewModelScope.launch {

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDescriptionSection.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeDescriptionSection.kt
@@ -34,8 +34,8 @@ fun ResumeDescriptionSection(
             Text(
                 text = stringResource(
                     R.string.resume_list_item_period,
-                    resumeListItem.startAt,
-                    resumeListItem.endAt
+                    resumeListItem.startAt.take(7),
+                    resumeListItem.endAt.take(7)
                 ),
                 color = CertiTheme.colors.gray500,
                 style = CertiTheme.typography.caption.regular_12

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeEditListItem.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeEditListItem.kt
@@ -20,10 +20,13 @@ import org.sopt.certi.ui.theme.CertiTheme
 fun ResumeEditListItem(
     resumeListItem: ActivityData,
     onDeleteClick: (Long) -> Unit,
+    onClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .noRippleClickable { onClick(resumeListItem.activityId) },
         verticalAlignment = Alignment.CenterVertically
     ) {
         ResumeDescriptionSection(

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeProfile.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeProfile.kt
@@ -9,18 +9,22 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import org.sopt.certi.R
 import org.sopt.certi.core.util.heightForScreenPercentage
 import org.sopt.certi.core.util.screenHeightDp
@@ -34,19 +38,34 @@ fun ResumeProfile(
     university: String,
     major: String,
     birthday: String,
+    profileImageUrl: String?,
     modifier: Modifier = Modifier
 ) {
     Row(
         modifier = modifier.padding(horizontal = screenWidthDp(20.dp)),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Image(
-            painter = painterResource(R.drawable.img_profile),
-            contentDescription = null,
-            modifier = Modifier
-                .widthForScreenPercentage(80.dp)
-                .heightForScreenPercentage(80.dp)
-        )
+        if (profileImageUrl == null) {
+            Image(
+                painter = painterResource(R.drawable.img_profile),
+                contentDescription = null,
+                modifier = Modifier
+                    .widthForScreenPercentage(80.dp)
+                    .heightForScreenPercentage(80.dp)
+            )
+        } else {
+            AsyncImage(
+                model = profileImageUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .widthForScreenPercentage(80.dp)
+                    .heightForScreenPercentage(80.dp)
+                    .clip(CircleShape),
+                contentScale = ContentScale.Crop,
+                placeholder = painterResource(R.drawable.img_profile),
+                error = painterResource(R.drawable.img_profile)
+            )
+        }
         Spacer(modifier = Modifier.width(screenWidthDp(16.dp)))
 
         Column(
@@ -130,6 +149,7 @@ private fun ResumeProfilePreview() {
         name = "김서티",
         university = "서티대학교",
         major = "시각디자인학과",
-        birthday = "2001. 03. 26 (만 24세)"
+        birthday = "2001. 03. 26 (만 24세)",
+        profileImageUrl = null
     )
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeProfile.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/component/ResumeProfile.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import org.sopt.certi.R
 import org.sopt.certi.core.util.heightForScreenPercentage
+import org.sopt.certi.core.util.noRippleClickable
 import org.sopt.certi.core.util.screenHeightDp
 import org.sopt.certi.core.util.screenWidthDp
 import org.sopt.certi.core.util.widthForScreenPercentage
@@ -39,6 +40,7 @@ fun ResumeProfile(
     major: String,
     birthday: String,
     profileImageUrl: String?,
+    navigateToMyPage: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Row(
@@ -82,19 +84,23 @@ fun ResumeProfile(
 
                 Spacer(modifier = Modifier.weight(1f))
 
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_edit_16),
-                    contentDescription = null,
-                    tint = CertiTheme.colors.gray400
-                )
+                Row(
+                    modifier = Modifier.noRippleClickable(navigateToMyPage)
+                ) {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_edit_16),
+                        contentDescription = null,
+                        tint = CertiTheme.colors.gray400
+                    )
 
-                Spacer(modifier = Modifier.widthForScreenPercentage(3.dp))
+                    Spacer(modifier = Modifier.widthForScreenPercentage(3.dp))
 
-                Text(
-                    text = stringResource(R.string.resume_profile_edit),
-                    style = CertiTheme.typography.caption.semibold_12,
-                    color = CertiTheme.colors.gray400
-                )
+                    Text(
+                        text = stringResource(R.string.resume_profile_edit),
+                        style = CertiTheme.typography.caption.semibold_12,
+                        color = CertiTheme.colors.gray400
+                    )
+                }
             }
 
             ResumeProfileItem(
@@ -150,6 +156,7 @@ private fun ResumeProfilePreview() {
         university = "서티대학교",
         major = "시각디자인학과",
         birthday = "2001. 03. 26 (만 24세)",
-        profileImageUrl = null
+        profileImageUrl = null,
+        navigateToMyPage = {}
     )
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/resume/navigation/ResumeNavigation.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/resume/navigation/ResumeNavigation.kt
@@ -5,9 +5,11 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navOptions
 import org.sopt.certi.core.navigation.MainTabRoute
 import org.sopt.certi.core.navigation.ResumeRoute
 import org.sopt.certi.presentation.ui.mypage.navigation.navigateToMyCertification
+import org.sopt.certi.presentation.ui.mypage.navigation.navigateToMyPage
 import org.sopt.certi.presentation.ui.resume.ResumeRoute
 
 fun NavController.navigateToResume(navOptions: NavOptions) {
@@ -29,6 +31,17 @@ fun NavGraphBuilder.resumeNavGraph(
     composable<MainTabRoute.Resume> {
         ResumeRoute(
             padding = padding,
+            navigateToMyPage = {
+                navController.navigateToMyPage(
+                    navOptions {
+                        popUpTo(MainTabRoute.Resume) {
+                            inclusive = false
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                )
+            },
             navigateToMyCert = navController::navigateToMyCertification,
             navigateToWorkExperience = navController::navigateToWorkExperience,
             navigateToActivities = navController::navigateToActivities

--- a/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/EditWorkExperienceViewModel.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/EditWorkExperienceViewModel.kt
@@ -1,0 +1,108 @@
+package org.sopt.certi.presentation.ui.workExperience
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import org.sopt.certi.domain.usecase.career.GetCareerListUseCase
+import org.sopt.certi.presentation.ui.workExperience.state.AddWorkExperienceUiState
+import javax.inject.Inject
+
+@HiltViewModel
+class EditWorkExperienceViewModel @Inject constructor(
+    private val getCareerListUseCase: GetCareerListUseCase,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val activityId: Long = checkNotNull(savedStateHandle["activityId"])
+
+    private val _startDate = MutableStateFlow("")
+    private val _endDate = MutableStateFlow("")
+    private val _organizationValue = MutableStateFlow("")
+    private val _roleValue = MutableStateFlow("")
+    private val _descriptionValue = MutableStateFlow("")
+
+    private val _editCareerSuccess = MutableStateFlow(false)
+    val editCareerSuccess: StateFlow<Boolean> = _editCareerSuccess
+
+    val uiState: StateFlow<AddWorkExperienceUiState> =
+        combine(
+            _startDate,
+            _endDate,
+            _organizationValue,
+            _roleValue,
+            _descriptionValue
+        ) { startDate, endDate, organization, role, description ->
+            AddWorkExperienceUiState(
+                startDate = startDate,
+                endDate = endDate,
+                organizationValue = organization,
+                roleValue = role,
+                descriptionValue = description,
+                addButtonEnabled = listOf(startDate, endDate, organization, role, description).all { it.isNotBlank() }
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = AddWorkExperienceUiState("", "", "", "", "", false)
+        )
+
+    init {
+        loadInitial()
+    }
+
+    private fun loadInitial() {
+        viewModelScope.launch {
+            getCareerListUseCase.invoke().fold(
+                onSuccess = { list ->
+                    val item = list.find { it.activityId == activityId }
+                    if (item != null) {
+                        _startDate.value = item.startAt
+                        _endDate.value = item.endAt
+                        _organizationValue.value = item.organization
+                        _roleValue.value = item.role
+                        _descriptionValue.value = item.description
+                    }
+                },
+                onFailure = {
+                }
+            )
+        }
+    }
+
+    fun onStartDateChanged(value: String) {
+        _startDate.value = value
+    }
+
+    fun onEndDateChanged(value: String) {
+        _endDate.value = value
+    }
+
+    fun onOrganizationChanged(value: String) {
+        _organizationValue.value = value
+    }
+
+    fun onRoleChanged(value: String) {
+        _roleValue.value = value
+    }
+
+    fun onDescriptionChanged(value: String) {
+        _descriptionValue.value = value
+    }
+
+    fun editCareer() {
+        viewModelScope.launch {
+            _editCareerSuccess.value = true
+        }
+    }
+
+    fun resetEditCareerSuccess() {
+        _editCareerSuccess.value = false
+    }
+}

--- a/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/EditWorkExperienceViewModel.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/EditWorkExperienceViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.sopt.certi.domain.usecase.career.EditCareerUseCase
 import org.sopt.certi.domain.usecase.career.GetCareerListUseCase
 import org.sopt.certi.presentation.ui.workExperience.state.AddWorkExperienceUiState
 import javax.inject.Inject
@@ -17,6 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class EditWorkExperienceViewModel @Inject constructor(
     private val getCareerListUseCase: GetCareerListUseCase,
+    private val editCareerUseCase: EditCareerUseCase,
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -68,9 +70,12 @@ class EditWorkExperienceViewModel @Inject constructor(
                         _organizationValue.value = item.organization
                         _roleValue.value = item.role
                         _descriptionValue.value = item.description
+                    } else {
+                        _editCareerSuccess.value = false
                     }
                 },
                 onFailure = {
+                    _editCareerSuccess.value = false
                 }
             )
         }
@@ -98,7 +103,21 @@ class EditWorkExperienceViewModel @Inject constructor(
 
     fun editCareer() {
         viewModelScope.launch {
-            _editCareerSuccess.value = true
+            editCareerUseCase(
+                careerId = activityId,
+                startAt = _startDate.value,
+                endAt = _endDate.value,
+                place = _organizationValue.value,
+                name = _roleValue.value,
+                description = _descriptionValue.value
+            ).fold(
+                onSuccess = {
+                    _editCareerSuccess.value = true
+                },
+                onFailure = {
+                    _editCareerSuccess.value = false
+                }
+            )
         }
     }
 

--- a/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/ResumeAddWorkExperienceScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/ResumeAddWorkExperienceScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -23,6 +24,7 @@ import org.sopt.certi.core.util.screenWidthDp
 import org.sopt.certi.presentation.ui.resume.component.ResumeDateInputSection
 import org.sopt.certi.presentation.ui.resume.component.ResumeTextInputSection
 import org.sopt.certi.presentation.ui.workExperience.state.AddWorkExperienceUiState
+import org.sopt.certi.ui.theme.CERTITheme
 import org.sopt.certi.ui.theme.CertiTheme
 
 @Composable
@@ -43,12 +45,44 @@ fun ResumeAddWorkExperienceRoute(
 
     ResumeAddWorkExperienceScreen(
         uiState = uiState,
-        onStartDateValueChange = { viewModel.onStartDateChanged(it) },
-        onEndDateValueChange = { viewModel.onEndDateChanged(it) },
-        onOrganizationValueChange = { viewModel.onOrganizationChanged(it) },
-        onRoleValueChange = { viewModel.onRoleChanged(it) },
-        onDescriptionValueChange = { viewModel.onDescriptionChanged(it) },
-        onAddClick = { viewModel.addCareer() },
+        titleResId = R.string.resume_work_experience_add_title,
+        buttonTextResId = R.string.button_add,
+        onStartDateValueChange = viewModel::onStartDateChanged,
+        onEndDateValueChange = viewModel::onEndDateChanged,
+        onOrganizationValueChange = viewModel::onOrganizationChanged,
+        onRoleValueChange = viewModel::onRoleChanged,
+        onDescriptionValueChange = viewModel::onDescriptionChanged,
+        onButtonClick = viewModel::addCareer,
+        modifier = Modifier.padding(padding)
+    )
+}
+
+@Composable
+fun ResumeEditWorkExperienceRoute(
+    padding: PaddingValues,
+    onNavigateToResume: () -> Unit,
+    viewModel: EditWorkExperienceViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val editSuccess by viewModel.editCareerSuccess.collectAsStateWithLifecycle()
+
+    LaunchedEffect(editSuccess) {
+        if (editSuccess) {
+            onNavigateToResume()
+            viewModel.resetEditCareerSuccess()
+        }
+    }
+
+    ResumeAddWorkExperienceScreen(
+        uiState = uiState,
+        titleResId = R.string.resume_work_experience_edit_title,
+        buttonTextResId = R.string.button_edit,
+        onStartDateValueChange = viewModel::onStartDateChanged,
+        onEndDateValueChange = viewModel::onEndDateChanged,
+        onOrganizationValueChange = viewModel::onOrganizationChanged,
+        onRoleValueChange = viewModel::onRoleChanged,
+        onDescriptionValueChange = viewModel::onDescriptionChanged,
+        onButtonClick = viewModel::editCareer,
         modifier = Modifier.padding(padding)
     )
 }
@@ -56,12 +90,14 @@ fun ResumeAddWorkExperienceRoute(
 @Composable
 fun ResumeAddWorkExperienceScreen(
     uiState: AddWorkExperienceUiState,
+    titleResId: Int,
+    buttonTextResId: Int,
     onStartDateValueChange: (String) -> Unit,
     onEndDateValueChange: (String) -> Unit,
     onOrganizationValueChange: (String) -> Unit,
     onRoleValueChange: (String) -> Unit,
     onDescriptionValueChange: (String) -> Unit,
-    onAddClick: () -> Unit,
+    onButtonClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -73,7 +109,7 @@ fun ResumeAddWorkExperienceScreen(
         ) {
             item {
                 Text(
-                    text = stringResource(R.string.resume_work_experience_add_title),
+                    text = stringResource(titleResId),
                     style = CertiTheme.typography.subtitle.semibold_20,
                     color = CertiTheme.colors.gray600,
                     modifier = Modifier.padding(top = screenHeightDp(60.dp), bottom = screenHeightDp(24.dp))
@@ -126,13 +162,38 @@ fun ResumeAddWorkExperienceScreen(
         }
 
         CertiBasicButton(
-            buttonText = stringResource(R.string.button_add),
-            onClick = onAddClick,
+            buttonText = stringResource(buttonTextResId),
+            onClick = onButtonClick,
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(bottom = screenHeightDp(24.dp))
                 .padding(horizontal = screenWidthDp(20.dp)),
             enabled = uiState.addButtonEnabled
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewResumeAddWorkExperienceScreen() {
+    CERTITheme {
+        ResumeAddWorkExperienceScreen(
+            uiState = AddWorkExperienceUiState(
+                startDate = "",
+                endDate = "",
+                organizationValue = "",
+                roleValue = "",
+                descriptionValue = "",
+                addButtonEnabled = true
+            ),
+            onStartDateValueChange = {},
+            onEndDateValueChange = {},
+            onOrganizationValueChange = {},
+            onRoleValueChange = {},
+            onDescriptionValueChange = {},
+            onButtonClick = {},
+            titleResId = R.string.resume_work_experience_add_title,
+            buttonTextResId = R.string.button_add
         )
     }
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/ResumeWorkExperienceScreen.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/ResumeWorkExperienceScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -36,6 +37,7 @@ import org.sopt.certi.ui.theme.CertiTheme
 fun ResumeWorkExperienceRoute(
     padding: PaddingValues,
     onNavigateToAddWordExperience: () -> Unit,
+    onNavigateToEditWorkExperience: (Long) -> Unit,
     viewModel: WorkExperienceViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.workExperienceUiState.collectAsStateWithLifecycle()
@@ -59,6 +61,7 @@ fun ResumeWorkExperienceRoute(
             onNavigateToAddWordExperience = onNavigateToAddWordExperience,
             resumeDataList = (uiState.experienceListLoadState as UiState.Success<List<ActivityData>>).data.toImmutableList(),
             onDeleteClick = { viewModel.onDeleteClick(it) },
+            onItemClick = onNavigateToEditWorkExperience,
             modifier = Modifier.padding(padding)
         )
 
@@ -87,6 +90,7 @@ fun ResumeWorkExperienceScreen(
     onNavigateToAddWordExperience: () -> Unit,
     resumeDataList: ImmutableList<ActivityData>,
     onDeleteClick: (Long) -> Unit,
+    onItemClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -116,8 +120,29 @@ fun ResumeWorkExperienceScreen(
             ResumeEditListItem(
                 resumeListItem = resumeData,
                 onDeleteClick = onDeleteClick,
+                onClick = onItemClick,
                 modifier = Modifier.padding(bottom = screenHeightDp(36.dp))
             )
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewResumeWorkExperienceScreen() {
+    ResumeWorkExperienceScreen(
+        onNavigateToAddWordExperience = {},
+        resumeDataList = listOf(
+            ActivityData(
+                activityId = 1,
+                startAt = "2025.01.01",
+                endAt = "2025.07.01",
+                organization = "SOPT",
+                role = "안드로이드 개발",
+                description = "안드로이드 OB"
+            )
+        ).toImmutableList(),
+        onDeleteClick = {},
+        onItemClick = {}
+    )
 }

--- a/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/navigation/WorkExperienceNavigation.kt
+++ b/app/src/main/java/org/sopt/certi/presentation/ui/workExperience/navigation/WorkExperienceNavigation.kt
@@ -9,10 +9,15 @@ import org.sopt.certi.core.navigation.MainTabRoute
 import org.sopt.certi.core.navigation.ResumeRoute
 import org.sopt.certi.presentation.ui.resume.navigation.navigateToResume
 import org.sopt.certi.presentation.ui.workExperience.ResumeAddWorkExperienceRoute
+import org.sopt.certi.presentation.ui.workExperience.ResumeEditWorkExperienceRoute
 import org.sopt.certi.presentation.ui.workExperience.ResumeWorkExperienceRoute
 
 fun NavController.navigateToAddWorkExperience() {
     navigate(ResumeRoute.AddWorkExperience)
+}
+
+fun NavController.navigateToEditWorkExperience(activityId: Long) {
+    navigate(ResumeRoute.EditWorkExperience(activityId))
 }
 
 fun NavGraphBuilder.workExperienceNavGraph(
@@ -22,7 +27,8 @@ fun NavGraphBuilder.workExperienceNavGraph(
     composable<ResumeRoute.WorkExperience> {
         ResumeWorkExperienceRoute(
             padding = padding,
-            onNavigateToAddWordExperience = navController::navigateToAddWorkExperience
+            onNavigateToAddWordExperience = navController::navigateToAddWorkExperience,
+            onNavigateToEditWorkExperience = navController::navigateToEditWorkExperience
         )
     }
 
@@ -34,6 +40,17 @@ fun NavGraphBuilder.workExperienceNavGraph(
                     navOptions {
                         popUpTo(MainTabRoute.Resume) { inclusive = true }
                     }
+                )
+            }
+        )
+    }
+
+    composable<ResumeRoute.EditWorkExperience> {
+        ResumeEditWorkExperienceRoute(
+            padding = padding,
+            onNavigateToResume = {
+                navController.navigateToResume(
+                    navOptions { popUpTo(MainTabRoute.Resume) { inclusive = true } }
                 )
             }
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <!-- ResumeCertificationCard -->
     <string name="resume_certification_card_small">%s년 %s월 %s일 획득</string>
     <string name="resume_certification_card_nickname">서티</string>
+    <string name="resume_certification_birthday_empty"> -</string>
 
     <!-- ResumeTextField -->
     <string name="resume_textfield_placeholder">텍스트를 작성해주세요.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="button_start">시작하기</string>
     <string name="button_apply">적용하기</string>
     <string name="button_add">추가하기</string>
+    <string name="button_edit">수정하기</string>
 
     <!-- MainBottomNavBar -->
     <string name="main_bottom_navbar_home">홈</string>


### PR DESCRIPTION
## Work Description ✏️
### 메인화면
- 사용자 정보 조회 API
- 정보수정 -> 마이페이지 이동
### 경력사항
- 경력사항 수정 API
- 경력사항 메인 → 수정뷰 데이터 넘기기
### 대내외활동
- 대내외활동 수정 API
- 대내외활동 메인 → 수정뷰 데이터 넘기기



## Screenshot 📸
https://github.com/user-attachments/assets/7229a895-0235-4a12-9742-d7bea6ebfe9a



## Uncompleted Tasks 😅
N/A

## To Reviewers 📢
이력서 파트 API 연결 모두 완료했습니다.